### PR TITLE
Add a 'read dataset' cell in visualise.ipynb

### DIFF
--- a/agage_archive/widgets.py
+++ b/agage_archive/widgets.py
@@ -139,3 +139,23 @@ def plot_to_output(sender, network, species, network_site, output_widget):
         clear_output(True)
         fig = plot_datasets(datasets)
         fig.show(renderer="notebook")
+
+
+def show_netcdf_info(sender, network, species, network_site, output_widget):
+
+    if not network_site:
+        with output_widget:
+            clear_output(True)
+            print("Please select a network and site") 
+
+    filenames = get_filenames(species, network_site)
+    datasets = load_datasets(network, filenames)
+
+    with output_widget:
+        clear_output()
+        for filename, dataset in zip(filenames, datasets):
+            print(filename)
+            print(dataset)
+            print("-----------------------------------------")
+            print("")
+

--- a/notebooks/visualise.ipynb
+++ b/notebooks/visualise.ipynb
@@ -210,13 +210,6 @@
     "\n",
     "print(dataset)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/notebooks/visualise.ipynb
+++ b/notebooks/visualise.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -15,7 +15,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -34,7 +34,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -44,9 +44,66 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "979c465d1171494f9310d71f81132ce1",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Dropdown(description='Species:', options=('c2f6', 'c3f8', 'c4f8', 'ccl4', 'cf4', 'cfc-11', 'cfc-113', 'cfc-114…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7778a71e4b1a41029605baeb0411f89c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "SelectMultiple(description='Site, instrument:', options=('CGO, AGAGE-GCMS-MEDUSA', 'GSN, AGAGE-GCMS-MEDUSA', '…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f2721e36e2234756b57e9e6915bc4f0f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Button(description='Plot', style=ButtonStyle())"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "02a7ae7dc5414057bd4808780aad584b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Output()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# Create dropdown widget\n",
     "species_dropdown = widgets.Dropdown(\n",
@@ -88,6 +145,73 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# View Dataset\n",
+    "\n",
+    "Extract a given species and site .nc file and print the xarray dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<xarray.Dataset>\n",
+      "Dimensions:           (time: 28503)\n",
+      "Coordinates:\n",
+      "  * time              (time) datetime64[ns] 2007-05-14T05:26:00 ... 2017-12-3...\n",
+      "Data variables:\n",
+      "    mf                (time) float32 nan nan nan nan ... 42.76 47.86 35.15 32.72\n",
+      "    mf_repeatability  (time) float32 nan nan nan nan ... 0.07228 0.05274 0.05015\n",
+      "    inlet_height      (time) int16 0 0 0 0 0 0 0 0 0 ... 17 17 17 17 17 17 17 17\n",
+      "    sampling_period   (time) int16 1200 1200 1200 1200 ... 1200 1200 1200 1200\n",
+      "Attributes: (12/20)\n",
+      "    comment:                    Medusa measurements. Output from GCWerks. See...\n",
+      "    github_url:                 https://github.com/mrghg/agage-archive\n",
+      "    data_owner_email:           sparky@knu.ac.kr\n",
+      "    data_owner:                 Sunyoung Park\n",
+      "    station_long_name:          Gosan, Jeju Island\n",
+      "    inlet_base_elevation_masl:  72.000000\n",
+      "    ...                         ...\n",
+      "    site_code:                  GSN\n",
+      "    network:                    agage\n",
+      "    doi:                        \n",
+      "    instrument:                 GCMS-Medusa\n",
+      "    instrument_date:            2007-05-14\n",
+      "    instrument_comment:         \n"
+     ]
+    }
+   ],
+   "source": [
+    "import xarray as xr\n",
+    "from agage_archive import open_data_file, Paths\n",
+    "\n",
+    "# change the species and site here - haven't set up a drop-down box or anything\n",
+    "\n",
+    "species='hfc-23' # must be in correct lower case format\n",
+    "site = 'GSN' # 3 letter site code\n",
+    "\n",
+    "\n",
+    "network='agage'\n",
+    "filename=f'{species}/AGAGE-GCMS-MEDUSA_{site}_{species}.nc'\n",
+    "paths = Paths(network, errors=\"ignore_inputs\")\n",
+    "\n",
+    "sub_path=paths.output_path\n",
+    "\n",
+    "with open_data_file(filename, network=network,sub_path=sub_path, errors=\"ignore_inputs\") as f:\n",
+    "    with xr.open_dataset(f) as ds:\n",
+    "        dataset = ds.load()\n",
+    "\n",
+    "print(dataset)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -111,7 +235,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,

--- a/notebooks/visualise.ipynb
+++ b/notebooks/visualise.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -10,12 +10,12 @@
     "from IPython.display import display\n",
     "\n",
     "from agage_archive import Paths, data_file_list\n",
-    "from agage_archive.widgets import update_instrument_site, plot_to_output"
+    "from agage_archive.widgets import update_instrument_site, plot_to_output, show_netcdf_info"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -34,7 +34,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -44,66 +44,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "979c465d1171494f9310d71f81132ce1",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Dropdown(description='Species:', options=('c2f6', 'c3f8', 'c4f8', 'ccl4', 'cf4', 'cfc-11', 'cfc-113', 'cfc-114…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7778a71e4b1a41029605baeb0411f89c",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "SelectMultiple(description='Site, instrument:', options=('CGO, AGAGE-GCMS-MEDUSA', 'GSN, AGAGE-GCMS-MEDUSA', '…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f2721e36e2234756b57e9e6915bc4f0f",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Button(description='Plot', style=ButtonStyle())"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "02a7ae7dc5414057bd4808780aad584b",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Output()"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Create dropdown widget\n",
     "species_dropdown = widgets.Dropdown(\n",
@@ -126,6 +69,7 @@
     "\n",
     "# Output widget\n",
     "output = widgets.Output()\n",
+    "output_netcdf = widgets.Output()\n",
     "\n",
     "# Update network and site dropdown when species is changed\n",
     "species_dropdown.observe(lambda change:\n",
@@ -137,78 +81,16 @@
     "                                              species_dropdown.value,\n",
     "                                              instrument_site.value,\n",
     "                                              output))\n",
+    "plot_button.on_click(lambda x: show_netcdf_info(x, network,\n",
+    "                                                species_dropdown.value,\n",
+    "                                                instrument_site.value,\n",
+    "                                                output_netcdf))                                         \n",
     "\n",
     "display(species_dropdown)\n",
     "display(instrument_site)\n",
     "display(plot_button)\n",
-    "display(output)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# View Dataset\n",
-    "\n",
-    "Extract a given species and site .nc file and print the xarray dataset"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 23,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "<xarray.Dataset>\n",
-      "Dimensions:           (time: 28503)\n",
-      "Coordinates:\n",
-      "  * time              (time) datetime64[ns] 2007-05-14T05:26:00 ... 2017-12-3...\n",
-      "Data variables:\n",
-      "    mf                (time) float32 nan nan nan nan ... 42.76 47.86 35.15 32.72\n",
-      "    mf_repeatability  (time) float32 nan nan nan nan ... 0.07228 0.05274 0.05015\n",
-      "    inlet_height      (time) int16 0 0 0 0 0 0 0 0 0 ... 17 17 17 17 17 17 17 17\n",
-      "    sampling_period   (time) int16 1200 1200 1200 1200 ... 1200 1200 1200 1200\n",
-      "Attributes: (12/20)\n",
-      "    comment:                    Medusa measurements. Output from GCWerks. See...\n",
-      "    github_url:                 https://github.com/mrghg/agage-archive\n",
-      "    data_owner_email:           sparky@knu.ac.kr\n",
-      "    data_owner:                 Sunyoung Park\n",
-      "    station_long_name:          Gosan, Jeju Island\n",
-      "    inlet_base_elevation_masl:  72.000000\n",
-      "    ...                         ...\n",
-      "    site_code:                  GSN\n",
-      "    network:                    agage\n",
-      "    doi:                        \n",
-      "    instrument:                 GCMS-Medusa\n",
-      "    instrument_date:            2007-05-14\n",
-      "    instrument_comment:         \n"
-     ]
-    }
-   ],
-   "source": [
-    "import xarray as xr\n",
-    "from agage_archive import open_data_file, Paths\n",
-    "\n",
-    "# change the species and site here - haven't set up a drop-down box or anything\n",
-    "\n",
-    "species='hfc-23' # must be in correct lower case format\n",
-    "site = 'GSN' # 3 letter site code\n",
-    "\n",
-    "\n",
-    "network='agage'\n",
-    "filename=f'{species}/AGAGE-GCMS-MEDUSA_{site}_{species}.nc'\n",
-    "paths = Paths(network, errors=\"ignore_inputs\")\n",
-    "\n",
-    "sub_path=paths.output_path\n",
-    "\n",
-    "with open_data_file(filename, network=network,sub_path=sub_path, errors=\"ignore_inputs\") as f:\n",
-    "    with xr.open_dataset(f) as ds:\n",
-    "        dataset = ds.load()\n",
-    "\n",
-    "print(dataset)"
+    "display(output)\n",
+    "display(output_netcdf)"
    ]
   }
  ],
@@ -228,7 +110,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Simply added a 'read dataset' cell in the visualise.ipynb notebook. Simply reads the files from the output path and loads as an xarray dataset. Might not work with the ALE/GAGE species which have slightly more complicated structures in the zip file. 

Need to change the code in the last cell to changes species/site - not a dropdown box as of yet