### PR TITLE
add new 'archive' file type

### DIFF
--- a/agage_archive/widgets.py
+++ b/agage_archive/widgets.py
@@ -33,8 +33,10 @@ def file_search_species(network, file_type, species, public = True):
         pattern = f"{species}/monthly-baseline/*.nc"
     elif file_type == "individual-instruments":
         pattern = f"{species}/individual-instruments/*.nc"
+    elif file_type == "archive":
+        pattern = f"{species}/archive/*nc"
     else:
-        raise ValueError("File type must be 'high-frequency', 'monthly-baseline' or 'individual-instruments'")
+        raise ValueError("File type must be 'high-frequency', 'monthly-baseline', 'individual-instruments' or 'archive'")
 
     files = data_file_list(network,
                            sub_path=f"{paths.output_path}",


### PR DESCRIPTION
Currently the file types are `high-frequency`, `monthly_baseline` and `individual-instruments`. Would be nice to add an extra file type here to account for archive data (and label it nicely as such in the file structure). 