### PR TITLE
Don't overwrite instrument date when combining files

### DIFF
--- a/agage_archive/formatting.py
+++ b/agage_archive/formatting.py
@@ -53,7 +53,8 @@ def format_attributes_global_instruments(ds,
     # If no instruments specified, check if they are in the dataset attributes
     if len(instruments) == 0:
         if "instrument" in ds.attrs:
-            instruments = [{key: ds.attrs[key] for key in ds.attrs if ("instrument" in key) and (key != "instrument_type")}]
+            instruments = [{key: ds.attrs[key] for key in ds.attrs if ("instrument" in key) and \
+                            (key != "instrument_type") and (key != "instrument_selection")}]
         else:
             raise ValueError("No instrument* attributes specified and none found in dataset attributes. " + \
                              "As a minimum, set keyword instrument = [{'instrument': 'INSTRUMENT_NAME'}]")
@@ -69,7 +70,7 @@ def format_attributes_global_instruments(ds,
     for attr in ds.attrs:
         if "instrument" not in attr:
             attrs[attr] = ds.attrs[attr]
-        elif attr == "instrument_type":
+        elif attr == "instrument_type" or attr == "instrument_selection":
             attrs[attr] = ds.attrs[attr]
 
     dates = []

--- a/agage_archive/io.py
+++ b/agage_archive/io.py
@@ -850,7 +850,7 @@ def combine_datasets(network, species, site,
 
         # Store instrument info and make sure the instrument_date is the same as in the filtered file
         instrument_rec.append({key:value for key, value in ds.attrs.items() if "instrument" in key})
-        instrument_rec[-1]["instrument_date"] = str(dates_rec[-1])
+        #instrument_rec[-1]["instrument_date"] = str(dates_rec[-1])
 
         # If variable mf_count is not present, add it (1 measurement per time point)
         if "mf_count" not in ds:

--- a/agage_archive/run.py
+++ b/agage_archive/run.py
@@ -675,7 +675,7 @@ if __name__ == "__main__":
     print("####################################")
     print("#####Processing public archive######")
     print("####################################")
-    run_all("agage", public=True)
+    run_all("agage", species = ["hfc-143a"], sites = ["TOB"], public=True)
 
     # print("####################################")
     # print("#####Processing private archive#####")

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -125,4 +125,4 @@ def test_format_attributes():
     assert ds.attrs["instrument_selection"] == "test"
     assert ds.attrs["version"] == "testv1"
 
-test_format_attributes()
+test_cf_compliance()

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -124,5 +124,3 @@ def test_format_attributes():
     assert ds.attrs["frequency"] == "high-frequency"
     assert ds.attrs["instrument_selection"] == "test"
     assert ds.attrs["version"] == "testv1"
-
-test_cf_compliance()


### PR DESCRIPTION
Instrument_date no longer overwritten when combining files. Now just carries over whatever is in the original file. See Issue #62 