### PR TITLE
read_gcwerks_flask needs to take scale argument

### DIFF
--- a/agage_archive/io.py
+++ b/agage_archive/io.py
@@ -664,7 +664,8 @@ def read_gcwerks_flask(network, species, site, instrument,
                        verbose = True,
                        public = True,
                        dropna=True,
-                       resample = False):
+                       resample = False,
+                       scale = "defaults"):
     '''Read GCWerks flask data
 
     Args:
@@ -676,6 +677,7 @@ def read_gcwerks_flask(network, species, site, instrument,
         public (bool, optional): Whether the dataset is for public release. Default to True.
         dropna (bool, optional): Drop NaN values. Default to True.
         resample (bool, optional): Dummy kwarg, needed for consistency with other functions. Default to False.
+        scale (str, optional): Scale to convert to - currently only accepts "defaults", which will read scale_defaults file.
 
     Returns:
         xr.Dataset: Dataset containing data
@@ -751,7 +753,10 @@ def read_gcwerks_flask(network, species, site, instrument,
         ds["mf_std"] = mf_std
 
     # Get cal scale from scale_defaults file
-    scale = calibration_scale_default(network, species)
+    if scale == "defaults":
+        scale = calibration_scale_default(network, species)
+    else:
+        raise ValueError("Flask data must use scale_defaults file")
 
     ds = format_attributes(ds,
                         network = network,


### PR DESCRIPTION
Now the call to `read_function` contains `scale=choose_scale_defaults_file(network, instrument)` we need this to work when `read_function == "read_gcwerks_flask"`. But we can't call `scale_convert` (as in the other cases) because there is no scale attribute in the flask .nc files. So here is a workaround for now (and it might do forever, unless we get flasks measured on more than one instrument)