### PR TITLE
Fix monthly baseline sampling period

### DIFF
--- a/data/variables.json
+++ b/data/variables.json
@@ -102,8 +102,8 @@
             "comment": "Time period over which sample was collected or averaged"
         },
         "encoding": {
-            "dtype": "i2",
-            "_FillValue": -99
+            "dtype": "i4",
+            "_FillValue": -9999
         },
         "optional": "True",
         "resample_method": "",


### PR DESCRIPTION
Fixes issue #136. Monthly baseline sampling periods were calculated incorrectly. Two issues:
a) wrong pandas function was being used to interpret the length of the "1MS" resampling frequency
b) integer length was too short for monthly sampling periods