### PR TITLE
remove check that network contains agage

### DIFF
--- a/agage_archive/io.py
+++ b/agage_archive/io.py
@@ -532,8 +532,8 @@ def read_ale_gage(network, species, site, instrument,
     Returns:
         pd.DataFrame: Pandas dataframe containing file contents
     """
-    if "agage" not in network:
-        raise ValueError("network must be agage or agage_test")
+    # if "agage" not in network:
+    #     raise ValueError("network must be agage or agage_test")
     
     if instrument not in ["ALE", "GAGE"]:
         raise ValueError("instrument must be ALE or GAGE")


### PR DESCRIPTION
I want to include the MHD GAGE data in my decc network files so I need to remove this check. I don't think it is doing anything useful?