### PR TITLE
Fix non-monotonic netCDF timestamps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,12 +73,25 @@ python -m pytest -q                                  # full suite, ~25 s
 python -m pytest -q --cov=agage_archive --cov-report=term-missing
 ```
 
+**Do not install, upgrade, or remove packages or otherwise modify the conda environment.**
+Until this repository moves to `uv`, dependency changes are handled manually by the
+maintainer. If a command fails because a package is missing or incompatible, stop and
+report the exact package name and any known version constraint so the maintainer can
+update the `agage` environment. Do not run `conda install`, `pip install`, or equivalent
+commands, and do not work around a missing dependency by changing project code.
+
 The package needs `agage_archive/config.yaml`, which is not in version control. Create it
 with `python agage_archive/config.py` if it is missing. Tests run against the `agage_test`
 network in `data/agage_test/`.
 
 ## Working practices
 
+- **Make changes on a dedicated branch and submit them through a pull request.** Before
+  editing, confirm that the current branch is not `main`; if it is, create a new,
+  descriptively named branch from the latest `main`. Keep unrelated tasks on separate
+  branches. When the work is complete, commit it, push the branch, and open an associated
+  GitHub pull request with the changes and test results. Do not commit directly to `main`
+  or merge the pull request unless explicitly asked.
 - **Run the tests before and after every change.** The suite is fast; there is no excuse
   for skipping it. Report failures with the actual output rather than summarising.
 - **Add the test first when fixing a bug.** Several bugs in this codebase sat in

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,9 @@ network in `data/agage_test/`.
   branches. When the work is complete, commit it, push the branch, and open an associated
   GitHub pull request with the changes and test results. Do not commit directly to `main`
   or merge the pull request unless explicitly asked.
+- **Keep `STATUS.md` current for every PR.** Before opening or updating a PR, set its
+  `Branch` and `Last updated` fields to the current branch and date, update any relevant
+  checkboxes and issue references, and record material decisions or test results.
 - **Run the tests before and after every change.** The suite is fast; there is no excuse
   for skipping it. Report failures with the actual output rather than summarising.
 - **Add the test first when fixing a bug.** Several bugs in this codebase sat in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Processing an instrument with no baseline flags (currently `GCMS-Medusa-flask`) while `baseline=True` raised `TypeError: 'NoneType' object is not callable`, which was swallowed into `error_log_individual.txt`, so flask data produced no output at all. Baseline and monthly-baseline products are now skipped for such instruments and the mole fraction files are written as normal.
 - The check that a baseline file has the same timestamps as its mole fraction file could never fire. `(ds_baseline.time != ds.time).any()` is an xarray comparison, which aligns both operands on the time coordinate before comparing, so every timestamp was compared with itself and the result was always `False` — for any input, including two datasets with no timestamps in common. It now compares the raw values. This was dead code in both `run_timestamp_checks` and `run_individual_site`; enabling it revealed no problems in existing data, but a genuine mismatch will now be caught instead of published.
 - `run_timestamp_checks` tested an `xarray.Dataset` for truthiness, so an empty baseline dataset silently skipped the duplicate-timestamp and timestamp-alignment checks rather than failing them.
+- `read_nc` now sorts inputs with non-monotonic timestamps. This path previously passed an unsupported `inplace` argument to `xarray.Dataset.sortby` and crashed instead of returning the data in timestamp order.
 
 ### Changed
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -154,10 +154,12 @@ explicit decision recorded in the log below before it lands.
 Each gets a failing test first, then the fix. Items 1–3 are the ones that can corrupt or
 silently mis-align published data.
 
-- [ ] **B1 — `sortby(inplace=True)` raises.** [io.py:307-308](agage_archive/io.py#L307-L308).
+- [x] **B1 — `sortby(inplace=True)` raises.** ✅ Fixed 2026-07-29.
+      [io.py:307-308](agage_archive/io.py#L307-L308).
       `Dataset.sortby()` has no `inplace` argument, and the result is discarded anyway, so
-      the non-monotonic branch is dead code that crashes when reached. Fix:
-      `ds = ds.sortby("time")`. Test: a fixture with shuffled timestamps.
+      the non-monotonic branch was dead code that crashed when reached. Replaced with
+      `ds = ds.sortby("time")` and covered by an in-memory shuffled input test in
+      [tests/test_io.py](tests/test_io.py).
 - [x] **B2 — the data/baseline timestamp check could never fire.** ✅ Fixed 2026-07-29.
       Worse than first recorded. `(ds_baseline.time != ds.time).any()` is an xarray
       comparison, which **aligns both operands on the time coordinate before comparing**,
@@ -323,8 +325,9 @@ modulo the three volatile attributes.
       `optional` ∈ {`"True"`, `"False"`}, `remove_flagged` ∈ {`"True"`, `"False"`, `"Zero"`},
       an `encoding.dtype` present in `nc4_types`, and a `resample_method` handled by
       `define_agg_dict`. Catches B8 and every future typo.
-- [ ] **T5 — Non-monotonic and duplicate-timestamp input fixtures** for `read_nc` (B1) and
-      `drop_duplicates` (P4).
+- [ ] **T5 — Non-monotonic and duplicate-timestamp input fixtures.** The in-memory
+      non-monotonic `read_nc` case (B1) is covered; the duplicate-timestamp case for
+      `drop_duplicates` (P4) remains outstanding.
 - [ ] **T6 — `util.archive_to_csv` end-to-end.** 0% covered and it produces a published
       archive.
 - [ ] **T7 — Input configuration consistency checks** (#97). Validate that species names

--- a/STATUS.md
+++ b/STATUS.md
@@ -4,9 +4,9 @@ Working plan for the code-quality pass on `agage-archive`. Read
 [AGENTS.md](AGENTS.md) first — in particular the rule that output files and archive
 structure must not change.
 
-**Branch:** `improved-tests`
+**Branch:** `fix-nonmonotonic-read-nc`
 **Started:** 2026-07-28
-**Last updated:** 2026-07-29
+**Last updated:** 2026-07-30
 
 Update the checkboxes and the "Last updated" date as items land. Keep the findings
 register at the bottom in sync — if an item turns out to be a non-issue, mark it

--- a/agage_archive/io.py
+++ b/agage_archive/io.py
@@ -288,7 +288,10 @@ def read_nc(network, species, site, instrument,
                             instrument,
                             species=format_species(species),
                             site=site)
-    ds = ds.sel(time=slice(None, rs))
+    if pd.Index(ds.time).is_monotonic_increasing:
+        ds = ds.sel(time=slice(None, rs))
+    else:
+        ds = ds.where(ds.time <= np.datetime64(rs), drop=True)
 
     # Rename some variables, so that they can be resampled properly
     if "mf_mean_N" in ds:
@@ -303,7 +306,7 @@ def read_nc(network, species, site, instrument,
     if resample:
         ds = resample_function(ds)
 
-    # Check that time is monotonic and that there are no duplicate indices
+    # Check that time is monotonic and remove duplicate indices
     if not pd.Index(ds.time).is_monotonic_increasing:
         ds = ds.sortby("time")
     if len(ds.time) != len(ds.time.drop_duplicates(dim="time")):

--- a/agage_archive/io.py
+++ b/agage_archive/io.py
@@ -305,7 +305,7 @@ def read_nc(network, species, site, instrument,
 
     # Check that time is monotonic and that there are no duplicate indices
     if not pd.Index(ds.time).is_monotonic_increasing:
-        ds.sortby("time", inplace=True)
+        ds = ds.sortby("time")
     if len(ds.time) != len(ds.time.drop_duplicates(dim="time")):
         ds = ds.drop_duplicates(dim="time")
 
@@ -1524,4 +1524,3 @@ def get_data_read_function(network, instrument):
         raise ValueError(error_message)
 
     return globals()[read_functions[instrument]]
-

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -2,6 +2,8 @@ import pandas as pd
 import xarray as xr
 import numpy as np
 import json
+from contextlib import nullcontext
+from unittest.mock import patch
 
 from agage_archive.config import Paths, open_data_file
 from agage_archive.io import read_ale_gage, read_nc, combine_datasets, read_nc_path, \
@@ -211,6 +213,19 @@ def test_timestamp():
 
     assert ds.time.attrs["long_name"] == "time"
     assert ds.time.attrs["comment"] == "Timestamp is the start of the sampling period in UTC"
+
+
+def test_read_nc_sorts_non_monotonic_timestamps():
+    filename, sub_path = read_nc_path("agage_test", "CH3CCl3", "CGO", "GCMS-Medusa")
+
+    with open_data_file(filename, network="agage_test", sub_path=sub_path) as f:
+        ds_original = xr.open_dataset(f).load()
+
+    shuffled = ds_original.isel(time=np.roll(np.arange(ds_original.sizes["time"]), 1))
+    with patch("agage_archive.io.open_data_file", return_value=nullcontext(shuffled)):
+        ds = read_nc("agage_test", "CH3CCl3", "CGO", "GCMS-Medusa", resample=False)
+
+    assert pd.Index(ds.time.values).is_monotonic_increasing
 
 
 def test_picarro():

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -2,7 +2,7 @@ import pandas as pd
 import xarray as xr
 import numpy as np
 import json
-from contextlib import nullcontext
+from io import BytesIO
 from unittest.mock import patch
 
 from agage_archive.config import Paths, open_data_file
@@ -222,7 +222,8 @@ def test_read_nc_sorts_non_monotonic_timestamps():
         ds_original = xr.open_dataset(f).load()
 
     shuffled = ds_original.isel(time=np.roll(np.arange(ds_original.sizes["time"]), 1))
-    with patch("agage_archive.io.open_data_file", return_value=nullcontext(shuffled)):
+    assert (shuffled.time.diff("time") < np.timedelta64(0, "ns")).any()
+    with patch("agage_archive.io.open_data_file", return_value=BytesIO(shuffled.to_netcdf())):
         ds = read_nc("agage_test", "CH3CCl3", "CGO", "GCMS-Medusa", resample=False)
 
     assert pd.Index(ds.time.values).is_monotonic_increasing


### PR DESCRIPTION
## Summary
- clarify agent branch/PR and conda environment rules
- sort non-monotonic `read_nc` inputs without using unsupported `inplace`
- apply release-schedule cutoffs safely before sorting non-monotonic datetime indexes
- add an in-memory shuffled-input regression test and update STATUS/CHANGELOG

## Tests
- `conda run -n agage python -m pytest -q tests/test_io.py -k test_read_nc_sorts_non_monotonic_timestamps` (1 passed)
- `conda run -n agage python -m pytest -q` (60 passed, 1 failed)

The full-suite failure is eight Picarro `data_checksum` differences in the golden manifest. The same differences reproduce with `tests/test_archive.py` on an untouched detached `origin/main` worktree in the same conda environment, so they are an existing environment/reference mismatch rather than a change introduced by this branch. The reference manifest was not regenerated.