### PR TITLE
Pin config error mode behavior

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -12,6 +12,10 @@ Update the checkboxes and the "Last updated" date as items land. Keep the findin
 register at the bottom in sync — if an item turns out to be a non-issue, mark it
 `WONTFIX` with a one-line reason rather than deleting it.
 
+The full suite currently has an existing baseline failure: eight Picarro checksum
+differences in the golden manifest, reproduced on `origin/main` with the current
+environment. Do not regenerate the manifest until the cause is resolved.
+
 ---
 
 ## Baseline
@@ -178,12 +182,13 @@ silently mis-align published data.
       `errors="ignore"` returns `None`; callers fail later with an unrelated
       `AttributeError`. The directory branch with `errors="raise"` returns a path to a
       non-existent file *without* raising — the two branches disagree about what `errors`
-      means. Fix alongside B5.
-- [ ] **B5 — `errors=` is four undocumented magic strings.** `raise`, `ignore`,
+      means. Current behavior is pinned by T3; fix alongside B5.
+- [ ] **B5 — `errors=` is four undocumented magic strings.** Current behavior is pinned by
+      T3. `raise`, `ignore`,
       `ignore_inputs`, `ignore_outputs`; the `Paths` docstring says the default is `raise`
       when it is `ignore`; [config.py:261](agage_archive/config.py#L261) uses substring
-      matching (`"ignore" in errors`) which matches all three ignore variants. Pin current
-      behaviour with the Phase 3 matrix test *before* simplifying.
+      matching (`"ignore" in errors`) which matches all three ignore variants. Simplify
+      only after reviewing the matrix.
 - [ ] **B6 — unbound local in `read_release_schedule`.**
       [data_selection.py:97-103](agage_archive/data_selection.py#L97-L103). `pos` is only
       assigned inside the comment-scanning loop, so a schedule file whose first line is not
@@ -318,9 +323,10 @@ modulo the three volatile attributes.
       tests for the determinism fixes, `data_combination_species`, the contested
       top-level file error and the flask baseline skip. Writing them is what exposed the
       true severity of B2.
-- [ ] **T3 — `config.py` error-mode matrix.** Parametrise
+- [x] **T3 — `config.py` error-mode matrix.** ✅ Done 2026-07-30. Parametrised
       `{raise, ignore, ignore_inputs, ignore_outputs}` × `{zip, dir}` ×
-      `{file present, absent}` and pin the current behaviour. Prerequisite for B4/B5.
+      `{file present, absent}` and pinned the current behavior in `tests/test_config.py`.
+      Prerequisite for B4/B5.
 - [ ] **T4 — Schema test over `data/variables.json` and `attributes.json`:** every entry has
       `optional` ∈ {`"True"`, `"False"`}, `remove_flagged` ∈ {`"True"`, `"False"`, `"Zero"`},
       an `encoding.dtype` present in `nc4_types`, and a `resample_method` handled by

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 import yaml
 import json
+import pytest
 
 from agage_archive.config import Paths, data_file_path, \
     open_data_file, data_file_list, output_path, archive_suffix
@@ -146,3 +147,29 @@ def test_archive_suffix():
     assert archive_suffix("folder", "-csv") == "folder-csv"
 
     assert archive_suffix(Path("archive.zip"), "-csv").name == Path("archive-csv.zip").name
+
+
+def test_error_mode_matrix():
+    """Document current error handling for directory and zip inputs."""
+    modes = ("raise", "ignore", "ignore_inputs", "ignore_outputs")
+
+    for mode in modes:
+        directory_path = data_file_path(
+            "test.txt", "agage_test", "path_test_files", errors=mode)
+        assert directory_path == repo_path / "data/agage_test/path_test_files/test.txt"
+
+        zip_path = data_file_path(
+            "B/C.txt", "agage_test", "path_test_files/A.zip", errors=mode)
+        assert zip_path == repo_path / "data/agage_test/path_test_files/A.zip"
+
+        directory_missing = data_file_path(
+            "missing.txt", "agage_test", "path_test_files", errors=mode)
+        assert directory_missing == repo_path / "data/agage_test/path_test_files/missing.txt"
+
+        if mode == "raise":
+            with pytest.raises(FileNotFoundError):
+                data_file_path(
+                    "missing.txt", "agage_test", "path_test_files/A.zip", errors=mode)
+        else:
+            assert data_file_path(
+                "missing.txt", "agage_test", "path_test_files/A.zip", errors=mode) is None


### PR DESCRIPTION
## Summary
- add the T3 config error-mode matrix for directory and zip inputs
- pin behavior for `raise`, `ignore`, `ignore_inputs`, and `ignore_outputs` with present and absent files
- update STATUS to mark T3 complete and record the existing golden-manifest baseline mismatch

This PR intentionally does not change B4/B5 behavior.

## Tests
- `conda run -n agage python -m pytest -q tests/test_config.py` (8 passed)
- `conda run -n agage python -m pytest -q` (61 passed, 1 failed)

The full-suite failure is the existing eight Picarro `data_checksum` differences in the golden manifest. They reproduce on untouched `origin/main` in the same environment; the manifest was not regenerated.