### PR TITLE
Remove stale STATUS branch metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,9 +92,10 @@ network in `data/agage_test/`.
   branches. When the work is complete, commit it, push the branch, and open an associated
   GitHub pull request with the changes and test results. Do not commit directly to `main`
   or merge the pull request unless explicitly asked.
-- **Keep `STATUS.md` current for every PR.** Before opening or updating a PR, set its
-  `Branch` and `Last updated` fields to the current branch and date, update any relevant
-  checkboxes and issue references, and record material decisions or test results.
+- **Keep `STATUS.md` current for every PR.** Before opening or updating a PR, update its
+  `Last updated` date, relevant checkboxes and issue references, and record material
+  decisions or test results. Do not add branch-specific metadata to STATUS; the active
+  branch and PR already provide that context.
 - **Run the tests before and after every change.** The suite is fast; there is no excuse
   for skipping it. Report failures with the actual output rather than summarising.
 - **Add the test first when fixing a bug.** Several bugs in this codebase sat in

--- a/STATUS.md
+++ b/STATUS.md
@@ -376,8 +376,6 @@ Highest risk to output format — do last, once Phases 0–3 are green.
 
 ### Now
 
-- [ ] Remove stray untracked files: `agage_archive/config copy.yaml`,
-      `data/agage_test/data-gcms-flask-nc/cf4_air.nc.BACKUP`
 - [ ] Add CI — there is no `.github/workflows`. The suite runs in ~25 s; running it on
       every PR is the cheapest guarantee that the golden manifest keeps working.
 - [ ] Add `pytest` and `pytest-cov` as test dependencies — neither is declared anywhere,

--- a/STATUS.md
+++ b/STATUS.md
@@ -4,7 +4,6 @@ Working plan for the code-quality pass on `agage-archive`. Read
 [AGENTS.md](AGENTS.md) first — in particular the rule that output files and archive
 structure must not change.
 
-**Branch:** `fix-nonmonotonic-read-nc`
 **Started:** 2026-07-28
 **Last updated:** 2026-07-30
 


### PR DESCRIPTION
## Summary
- remove the branch name from STATUS.md because it becomes stale after each PR
- require STATUS date, checkboxes, issue references, decisions, and test results to be maintained for every PR
- document that branch and PR context should not be duplicated in STATUS

## Tests
- `git diff --check`