### PR TITLE
Clarify config error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The check that a baseline file has the same timestamps as its mole fraction file could never fire. `(ds_baseline.time != ds.time).any()` is an xarray comparison, which aligns both operands on the time coordinate before comparing, so every timestamp was compared with itself and the result was always `False` — for any input, including two datasets with no timestamps in common. It now compares the raw values. This was dead code in both `run_timestamp_checks` and `run_individual_site`; enabling it revealed no problems in existing data, but a genuine mismatch will now be caught instead of published.
 - `run_timestamp_checks` tested an `xarray.Dataset` for truthiness, so an empty baseline dataset silently skipped the duplicate-timestamp and timestamp-alignment checks rather than failing them.
 - `read_nc` now sorts inputs with non-monotonic timestamps. This path previously passed an unsupported `inplace` argument to `xarray.Dataset.sortby` and crashed instead of returning the data in timestamp order.
+- `data_file_path` now validates `errors` modes and consistently raises `FileNotFoundError` for missing files when `errors="raise"`, including files in directories.
 
 ### Changed
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -176,18 +176,18 @@ silently mis-align published data.
 - [x] **B3 — `if ds_baseline:` is Dataset truthiness.** ✅ Fixed 2026-07-29 in
       `run_timestamp_checks` and `run_individual_site`. Covered by
       [tests/test_run.py](tests/test_run.py).
-- [ ] **B4 — `data_file_path` returns `None` silently.**
+- [x] **B4 — `data_file_path` returns `None` silently.** ✅ Fixed 2026-07-30.
       [config.py:335-340](agage_archive/config.py#L335-L340). Zip + missing member +
       `errors="ignore"` returns `None`; callers fail later with an unrelated
       `AttributeError`. The directory branch with `errors="raise"` returns a path to a
-      non-existent file *without* raising — the two branches disagree about what `errors`
-      means. Current behavior is pinned by T3; fix alongside B5.
-- [ ] **B5 — `errors=` is four undocumented magic strings.** Current behavior is pinned by
-      T3. `raise`, `ignore`,
+      non-existent file *without* raising — the two branches disagreed about what `errors`
+      means. `data_file_path` now raises consistently for missing files in `raise` mode.
+- [x] **B5 — `errors=` is four undocumented magic strings.** ✅ Fixed 2026-07-30.
+      `raise`, `ignore`,
       `ignore_inputs`, `ignore_outputs`; the `Paths` docstring says the default is `raise`
       when it is `ignore`; [config.py:261](agage_archive/config.py#L261) uses substring
-      matching (`"ignore" in errors`) which matches all three ignore variants. Simplify
-      only after reviewing the matrix.
+      matching (`"ignore" in errors`) which matches all three ignore variants. Invalid
+      values now raise `ValueError` with the accepted modes.
 - [ ] **B6 — unbound local in `read_release_schedule`.**
       [data_selection.py:97-103](agage_archive/data_selection.py#L97-L103). `pos` is only
       assigned inside the comment-scanning loop, so a schedule file whose first line is not
@@ -324,8 +324,8 @@ modulo the three volatile attributes.
       true severity of B2.
 - [x] **T3 — `config.py` error-mode matrix.** ✅ Done 2026-07-30. Parametrised
       `{raise, ignore, ignore_inputs, ignore_outputs}` × `{zip, dir}` ×
-      `{file present, absent}` and pinned the current behavior in `tests/test_config.py`.
-      Prerequisite for B4/B5.
+      `{file present, absent}` and pinned the corrected behavior in `tests/test_config.py`.
+      It remains the regression test for B4/B5.
 - [ ] **T4 — Schema test over `data/variables.json` and `attributes.json`:** every entry has
       `optional` ∈ {`"True"`, `"False"`}, `remove_flagged` ∈ {`"True"`, `"False"`, `"Zero"`},
       an `encoding.dtype` present in `nc4_types`, and a `resample_method` handled by

--- a/agage_archive/config.py
+++ b/agage_archive/config.py
@@ -8,6 +8,9 @@ from shutil import copy, rmtree
 import os
 
 
+ERROR_MODES = {"raise", "ignore", "ignore_inputs", "ignore_outputs"}
+
+
 class Paths():
 
     def __init__(self,
@@ -32,6 +35,10 @@ class Paths():
             FileNotFoundError: If folder or zip archive doesn't exist
             FileNotFoundError: If folder or zip archive is not a folder or zip archive   
         """
+
+        if errors not in ERROR_MODES:
+            raise ValueError(
+                f"Unknown errors mode {errors!r}; expected one of {sorted(ERROR_MODES)}")
 
         # Get repository root
         # Do this by finding the location of the .git folder in the working directory
@@ -339,6 +346,9 @@ def data_file_path(filename,
             if errors == "raise":
                 raise FileNotFoundError(f"Can't find {filename} in {pth}")
     else:
+        file_path = pth / filename
+        if errors == "raise" and not file_path.exists():
+            raise FileNotFoundError(f"Can't find file {file_path}")
         return pth / filename
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -162,9 +162,14 @@ def test_error_mode_matrix():
             "B/C.txt", "agage_test", "path_test_files/A.zip", errors=mode)
         assert zip_path == repo_path / "data/agage_test/path_test_files/A.zip"
 
-        directory_missing = data_file_path(
-            "missing.txt", "agage_test", "path_test_files", errors=mode)
-        assert directory_missing == repo_path / "data/agage_test/path_test_files/missing.txt"
+        if mode == "raise":
+            with pytest.raises(FileNotFoundError):
+                data_file_path(
+                    "missing.txt", "agage_test", "path_test_files", errors=mode)
+        else:
+            directory_missing = data_file_path(
+                "missing.txt", "agage_test", "path_test_files", errors=mode)
+            assert directory_missing == repo_path / "data/agage_test/path_test_files/missing.txt"
 
         if mode == "raise":
             with pytest.raises(FileNotFoundError):
@@ -173,3 +178,13 @@ def test_error_mode_matrix():
         else:
             assert data_file_path(
                 "missing.txt", "agage_test", "path_test_files/A.zip", errors=mode) is None
+
+
+def test_invalid_error_mode_raises_value_error():
+    with pytest.raises(ValueError, match="Unknown errors mode"):
+        data_file_path("test.txt", "agage_test", "path_test_files", errors="unexpected")
+
+
+def test_raise_mode_checks_missing_directory_file():
+    with pytest.raises(FileNotFoundError, match="missing.txt"):
+        data_file_path("missing.txt", "agage_test", "path_test_files", errors="raise")


### PR DESCRIPTION
## Summary
- validate the four supported `errors` modes
- make `errors="raise"` consistently raise for missing directory files and ZIP members
- cover the corrected directory/ZIP and present/absent matrix
- mark B4/B5 complete in STATUS and document the behavior change

## Tests
- `conda run -n agage python -m pytest -q tests/test_config.py` (10 passed)
- `conda run -n agage python -m pytest -q` (63 passed, 1 failed)

The full-suite failure is the known eight Picarro `data_checksum` differences in the golden manifest. They reproduce on untouched `origin/main` in the same environment; the manifest was not regenerated.