### PR TITLE
Normalize release schedule species lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `read_nc` now sorts inputs with non-monotonic timestamps. This path previously passed an unsupported `inplace` argument to `xarray.Dataset.sortby` and crashed instead of returning the data in timestamp order.
 - `data_file_path` now validates `errors` modes and consistently raises `FileNotFoundError` for missing files when `errors="raise"`, including files in directories.
 - `read_release_schedule` now handles schedule files without comment headers instead of raising `UnboundLocalError`.
+- `read_release_schedule` now applies species matching case-insensitively to both validation and row lookup.
 
 ### Changed
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -193,11 +193,11 @@ silently mis-align published data.
       assigned inside the comment-scanning loop, so a schedule file whose first line is not
       a comment raised `UnboundLocalError` at `f.seek(pos)`. Initialize the rewind position
       before scanning; covered by a no-comment-header in-memory schedule test.
-- [ ] **B7 — species case mismatch between validation and lookup.**
+- [x] **B7 — species case mismatch between validation and lookup.** ✅ Fixed 2026-07-30.
       [data_selection.py:122-131](agage_archive/data_selection.py#L122-L131) and
       [data_selection.py:197-200](agage_archive/data_selection.py#L197-L200) validate with
-      `format_species(species)` then index with the raw `species`. Works only because all
-      current callers pre-format.
+      `format_species(species)` then indexed with the raw `species`. Normalize the matched
+      index label before lookup; covered by a mixed-case species test.
 - [ ] **B8 — `instrument_type` is accidentally optional.** `data/variables.json` has
       `"optional": ""`, and [formatting.py:261](agage_archive/formatting.py#L261) treats
       anything other than the exact string `"False"` as optional — so a missing

--- a/agage_archive/data_selection.py
+++ b/agage_archive/data_selection.py
@@ -162,8 +162,11 @@ def read_release_schedule(network, instrument,
 
     if species is not None:
 
-        if format_species(species) not in df.index.str.lower():
+        species = format_species(species)
+        species_index = df.index[df.index.str.lower() == species.lower()]
+        if len(species_index) == 0:
             raise ValueError(f"No release schedule found for {species} at {site}")
+        species = species_index[0]
 
         if df.loc[species, site] == "x":
             # Return a value before any data was collected, to remove everything

--- a/tests/test_data_selection.py
+++ b/tests/test_data_selection.py
@@ -132,6 +132,8 @@ def test_read_release_schedule():
     # A blank cell falls back to the general release date
     assert read_release_schedule("agage_test", "Picarro",
                                  species = "ch4", site = "TAC") == "2023-01-01 00:00"
+    assert read_release_schedule("agage_test", "Picarro",
+                                 species = "CH4", site = "TAC") == "2023-01-01 00:00"
 
 
 def test_read_release_schedule_without_comment_header():


### PR DESCRIPTION
## Summary
- normalize the matched release-schedule species label before row lookup
- accept mixed-case species names through `read_release_schedule`
- add a regression test and mark B7 complete in STATUS

## Tests
- `conda run -n agage python -m pytest -q tests/test_data_selection.py -k test_read_release_schedule` (2 passed)
- `conda run -n agage python -m pytest -q` (64 passed, 1 failed)

The full-suite failure is the known eight Picarro `data_checksum` differences in the golden manifest. They reproduce on untouched `origin/main` in the same environment; the manifest was not regenerated.