### PR TITLE
Scope formatting warning filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `read_release_schedule` now handles schedule files without comment headers instead of raising `UnboundLocalError`.
 - `read_release_schedule` now applies species matching case-insensitively to both validation and row lookup.
 - `instrument_type` is now required by the variable schema, so missing values raise instead of being silently omitted.
+- `format_variables` now scopes its casting warning filter and restores the caller's warning configuration.
 
 ### Changed
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -206,10 +206,10 @@ silently mis-align published data.
 - [x] **B9 — flask + baseline fails via the generic handler.** ✅ Fixed 2026-07-29.
       Baseline and monthly products are skipped when `read_baseline_function is None`;
       the `NotImplementedError` for "monthly without baseline" is preserved.
-- [ ] **B10 — `warnings.simplefilter` used as a global toggle.**
+- [x] **B10 — `warnings.simplefilter` used as a global toggle.** ✅ Fixed 2026-07-30.
       [formatting.py:275-280](agage_archive/formatting.py#L275-L280) clobbers the caller's
-      warning configuration and does not restore it on exception. Fix:
-      `with warnings.catch_warnings():`.
+      warning configuration and did not restore it on exception. Wrapped the cast in
+      `warnings.catch_warnings()` and covered filter restoration with a regression test.
 - [ ] **B11 — module-level filesystem walk at import.**
       [io_other_formats.py:11](agage_archive/io_other_formats.py#L11) runs `Paths()` at
       import time and can raise on import; [line 52](agage_archive/io_other_formats.py#L52)

--- a/agage_archive/formatting.py
+++ b/agage_archive/formatting.py
@@ -271,13 +271,11 @@ def format_variables(ds,
                 # This variable is optional and not present, so we can skip it
                 continue
 
-        # Error on warnings, in case casting to type causes problems
-        warnings.simplefilter("error")
-
-        var_temp[np.isnan(var_temp)] = missing_value
-        vars_out[var] = ("time", var_temp.copy().astype(typ))
-
-        warnings.simplefilter("default")
+        # Error on warnings during casting without changing the caller's filters.
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            var_temp[np.isnan(var_temp)] = missing_value
+            vars_out[var] = ("time", var_temp.copy().astype(typ))
 
     # Create new dataset
     ds = xr.Dataset(vars_out,

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -8,6 +8,7 @@ import json
 from agage_archive.config import open_data_file, data_file_path
 from agage_archive.run import run_individual_instrument
 from agage_archive.formatting import format_attributes
+from agage_archive.formatting import format_variables
 
 
 def check_cf_compliance(dataset):
@@ -60,6 +61,28 @@ def test_variable_schema():
         assert definition["encoding"]["dtype"] in valid_dtypes, variable
         if "resample_method" in definition:
             assert definition["resample_method"] in valid_resample_methods, variable
+
+
+def test_format_variables_restores_warning_filters():
+    ds = xr.Dataset(
+        {"mf": ("time", np.array([1.0]))},
+        coords={"time": pd.date_range("2021-01-01", periods=1)},
+        attrs={"network": "agage_test", "species": "nf3", "calibration_scale": "SIO-05"},
+    )
+    ds["mf"].attrs["units"] = "1e-9"
+    with open_data_file("variables.json", this_repo=True) as f:
+        variables = json.load(f)
+    translation = {
+        variable: "mf"
+        for variable, definition in variables.items()
+        if variable != "time" and definition["optional"] == "False"
+    }
+    original_filters = warnings.filters[:]
+
+    try:
+        format_variables(ds, variable_translate=translation)
+    finally:
+        assert warnings.filters == original_filters
 
 
 def test_cf_compliance(clean_output):


### PR DESCRIPTION
## Summary
- wrap formatting casts in `warnings.catch_warnings()`
- preserve the caller's warning filter configuration on success and failure
- add a regression test and mark B10 complete in STATUS
- update the changelog

## Tests
- `conda run -n agage python -m pytest -q tests/test_formatting.py -k test_format_variables_restores_warning_filters` (1 passed)
- `conda run -n agage python -m pytest -q` (66 passed, 1 failed)

The full-suite failure is the known eight Picarro `data_checksum` differences in the golden manifest. They reproduce on untouched `origin/main` in the same environment; the manifest was not regenerated.