### PR TITLE
Make optional format reader import safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `read_release_schedule` now applies species matching case-insensitively to both validation and row lookup.
 - `instrument_type` is now required by the variable schema, so missing values raise instead of being silently omitted.
 - `format_variables` now scopes its casting warning filter and restores the caller's warning configuration.
+- The optional Wang reader no longer resolves paths at module import and now uses the pandas-compatible whitespace separator syntax.
 
 ### Changed
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -210,11 +210,11 @@ silently mis-align published data.
       [formatting.py:275-280](agage_archive/formatting.py#L275-L280) clobbers the caller's
       warning configuration and did not restore it on exception. Wrapped the cast in
       `warnings.catch_warnings()` and covered filter restoration with a regression test.
-- [ ] **B11 — module-level filesystem walk at import.**
+- [x] **B11 — module-level filesystem walk at import.** ✅ Fixed 2026-07-30.
       [io_other_formats.py:11](agage_archive/io_other_formats.py#L11) runs `Paths()` at
-      import time and can raise on import; [line 52](agage_archive/io_other_formats.py#L52)
-      uses `delim_whitespace=True`, removed in pandas 3.0. 0% coverage — decide whether to
-      test it or delete it.
+      import time and could raise on import; [line 52](agage_archive/io_other_formats.py#L52)
+      used `delim_whitespace=True`, removed in pandas 3.0. Path resolution is now lazy and
+      whitespace parsing uses `sep=r"\s+"`; covered by import and parser tests.
 - [ ] **B12 — `start_date` is too early in individual-instrument files.** *Agreed to fix
       (2026-07-29), scheduled after the current PR.*
 

--- a/agage_archive/io_other_formats.py
+++ b/agage_archive/io_other_formats.py
@@ -8,7 +8,6 @@ from fnmatch import fnmatch
 from agage_archive.config import Paths as Pth
 from agage_archive.util import tz_local_to_utc
 
-paths = Pth()
 home = Path.home()
 
 species_wang = {
@@ -49,7 +48,7 @@ def read_wang_file(file, header_lines=6):
     file.seek(0)
 
     # Read the file into a Pandas dataframe with correct headers
-    complete_data = pd.read_csv(file, skiprows=header_lines, delim_whitespace=True,
+    complete_data = pd.read_csv(file, skiprows=header_lines, sep=r"\s+",
                                 names=first_lines[header_lines-1].split(), encoding='ascii')
 
     complete_data.columns = complete_data.columns.astype(str)
@@ -93,6 +92,8 @@ def read_wang(species, site, network, instrument, utc = False):
     Returns:
         df (pd.DataFrame): Dataframe with one column for the species
     """
+
+    paths = Pth()
 
     # Read ale_gage_sites.json
     with open(paths.root.parent / f"data/{network}/ale_gage_sites.json", "r") as file:

--- a/tests/test_io_other_formats.py
+++ b/tests/test_io_other_formats.py
@@ -1,0 +1,27 @@
+from io import StringIO
+
+import pandas as pd
+
+from agage_archive.io_other_formats import read_wang_file
+
+
+def test_io_other_formats_imports_without_config():
+    """Importing the optional reader must not require a runtime config file."""
+    import agage_archive.io_other_formats  # noqa: F401
+
+
+def test_read_wang_file_parses_whitespace_separated_data():
+    data = StringIO(
+        "# header\n"
+        "# header\n"
+        "# header\n"
+        "# header\n"
+        "# header\n"
+        "YYYY MM DD hh min time ABSDA CFC-11S\n"
+        "2020 1 2 3 4 0 0 1.5\n"
+    )
+
+    result = read_wang_file(data)
+
+    assert result.index[0] == pd.Timestamp("2020-01-02 03:04")
+    assert result["CFC-11S"].iloc[0] == 1.5


### PR DESCRIPTION
## Summary
- remove module-level `Paths()` construction from `io_other_formats`
- resolve paths lazily inside `read_wang`
- replace removed `delim_whitespace` with `sep=r"\s+"`
- add import and synthetic parser tests
- mark B11 complete and update the changelog

## Tests
- `conda run -n agage python -m pytest -q tests/test_io_other_formats.py` (2 passed)
- `conda run -n agage python -m pytest -q` (68 passed, 1 failed)

The full-suite failure is the known eight Picarro `data_checksum` differences in the golden manifest. They reproduce on untouched `origin/main` in the same environment; the manifest was not regenerated.