### PR TITLE
Recompute output date attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `instrument_type` is now required by the variable schema, so missing values raise instead of being silently omitted.
 - `format_variables` now scopes its casting warning filter and restores the caller's warning configuration.
 - The optional Wang reader no longer resolves paths at module import and now uses the pandas-compatible whitespace separator syntax.
+- Output datasets now recompute both `start_date` and `end_date` after final release-date filtering, so individual files no longer report the source record's earlier start date.
 
 ### Changed
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -215,8 +215,7 @@ silently mis-align published data.
       import time and could raise on import; [line 52](agage_archive/io_other_formats.py#L52)
       used `delim_whitespace=True`, removed in pandas 3.0. Path resolution is now lazy and
       whitespace parsing uses `sep=r"\s+"`; covered by import and parser tests.
-- [ ] **B12 — `start_date` is too early in individual-instrument files.** *Agreed to fix
-      (2026-07-29), scheduled after the current PR.*
+- [x] **B12 — `start_date` is too early in individual-instrument files.** ✅ Fixed 2026-07-30.
 
       All four readers call `format_attributes` before removing NaN mole fractions
       ([io.py:269](agage_archive/io.py#L269), [643](agage_archive/io.py#L643),
@@ -245,12 +244,10 @@ silently mis-align published data.
       contributing datasets were each read with `dropna=True`. With `dropna=False` they
       would be wrong too.
 
-      **Preferred fix:** compute `start_date` and `end_date` in `output_dataset`, at write
-      time, where the dataset is definitely final — rather than patching each reader.
-      That removes the whole class of "derived attribute computed too early" rather than
-      this one instance, and subsumes the existing `end_date` special case. Changes an
-      attribute on ~618 files in the real archive. Do it alongside Phase 1b/A3, which is
-      the same underlying problem.
+      **Fix:** compute `start_date` and `end_date` in `output_dataset`, at write time, where
+      the dataset is definitely final. This removes the whole class of "derived attribute
+      computed too early" rather than this one instance, and subsumes the existing
+      `end_date` special case. Changes an attribute on ~618 files in the real archive.
 
 - [ ] **B13 — Magnum inlet attributes have inconsistent types** (#171). Magnum files
       expose `inlet_base_elevation_masl`, `inlet_latitude`, and `inlet_longitude` as
@@ -444,7 +441,8 @@ Record anything that changes the plan, especially anything touching output forma
 | 2026-07-29 | Combined-file global attributes now come from the most recently operating instrument (#167). Follow-on attribute work tracked as Phase 1b together with #169. |
 | 2026-07-29 | Version bumped to 0.3.0. This branch changes published output, and `processing_code_version` is written into every file, so archives built from it must not claim to be 0.2.1. |
 | 2026-07-29 | B2 fixed after targeted tests showed the check was not merely weak but completely dead. Enabling it changes no output; it only means a genuine data/baseline mismatch now fails instead of being published. |
-| 2026-07-29 | B12 (`start_date` too early in individual-instrument files) will be fixed, but not in the current PR. Preferred approach: compute the date attributes at write time in `output_dataset` rather than in each reader. |
+| 2026-07-29 | B12 (`start_date` too early in individual-instrument files) was approved for a later PR. Preferred approach: compute the date attributes at write time in `output_dataset` rather than in each reader. |
+| 2026-07-30 | B12 fix approved for landing: recompute `start_date` and `end_date` in `output_dataset` after final filtering. This intentionally changes published attributes on affected files; regenerate the golden manifest after review. |
 | 2026-07-29 | **Contested top-level files now raise.** If more than one instrument is eligible to write `{species}/` because the species has no row in the site's `data_combination` file, processing fails with an error naming the species and site, rather than letting run order decide. Sites in the real archive have already been corrected by hand; this makes a regression impossible to miss. |
 
 ### Open questions

--- a/agage_archive/io.py
+++ b/agage_archive/io.py
@@ -1497,6 +1497,9 @@ def output_dataset(ds, network,
         raise ValueError(f"No data retained for {ds_out.attrs['species']} when trying write {filename} after applying release schedule end dates. " + \
                         "Check dates in release schedule or omit this instrument.")
 
+    ds_out.attrs["start_date"] = str(ds_out.time[0].dt.strftime("%Y-%m-%d %H:%M:%S").values)
+    ds_out.attrs["end_date"] = str(ds_out.time[-1].dt.strftime("%Y-%m-%d %H:%M:%S").values)
+
     output_write(ds_out, out_path, filename,
                 output_subpath=output_subpath, verbose=verbose)
 

--- a/tests/reference/archive_manifest.json
+++ b/tests/reference/archive_manifest.json
@@ -220,7 +220,7 @@
    "product_type": "mole fraction",
    "site_code": "CGO",
    "species": "ccl4",
-   "start_date": "1978-07-08 05:08:00",
+   "start_date": "1978-07-08 21:35:00",
    "station_long_name": "Kennaook/Cape Grim, Tasmania, Australia",
    "version": "testv1"
   },
@@ -351,7 +351,7 @@
    "product_type": "mole fraction",
    "site_code": "CGO",
    "species": "ccl4",
-   "start_date": "1981-11-30 14:01:00",
+   "start_date": "1981-12-01 10:25:00",
    "station_long_name": "Kennaook/Cape Grim, Tasmania, Australia",
    "version": "testv1"
   },
@@ -595,7 +595,7 @@
    "product_type": "mole fraction",
    "site_code": "CGO",
    "species": "ccl4",
-   "start_date": "1978-07-08 05:08:00",
+   "start_date": "1978-07-01 00:00:00",
    "station_long_name": "Kennaook/Cape Grim, Tasmania, Australia",
    "version": "testv1"
   },
@@ -728,7 +728,7 @@
    "product_type": "mole fraction",
    "site_code": "CGO",
    "species": "ccl4",
-   "start_date": "1981-11-30 14:01:00",
+   "start_date": "1981-12-01 00:00:00",
    "station_long_name": "Kennaook/Cape Grim, Tasmania, Australia",
    "version": "testv1"
   },
@@ -845,7 +845,7 @@
    "data_owner": "Paul Krummel",
    "data_owner_email": "paul.krummel@csiro.au",
    "doi": "",
-   "end_date": "1994-12-29 22:41:00",
+   "end_date": "1994-12-01 00:00:00",
    "frequency": "monthly baseline",
    "inlet_base_elevation_masl": "94.0",
    "inlet_comment": "",
@@ -864,7 +864,7 @@
    "product_type": "mole fraction",
    "site_code": "CGO",
    "species": "ccl4",
-   "start_date": "1978-07-08 21:35:00",
+   "start_date": "1978-07-01 00:00:00",
    "station_long_name": "Kennaook/Cape Grim, Tasmania, Australia",
    "version": "testv1"
   },
@@ -1477,7 +1477,7 @@
    "product_type": "mole fraction",
    "site_code": "CGO",
    "species": "cfc-11",
-   "start_date": "1978-07-08 05:08:00",
+   "start_date": "1978-07-08 09:13:00",
    "station_long_name": "Kennaook/Cape Grim, Tasmania, Australia",
    "version": "testv1"
   },
@@ -1608,7 +1608,7 @@
    "product_type": "mole fraction",
    "site_code": "CGO",
    "species": "cfc-11",
-   "start_date": "1981-11-30 14:01:00",
+   "start_date": "1981-12-01 13:27:00",
    "station_long_name": "Kennaook/Cape Grim, Tasmania, Australia",
    "version": "testv1"
   },
@@ -1852,7 +1852,7 @@
    "product_type": "mole fraction",
    "site_code": "CGO",
    "species": "cfc-11",
-   "start_date": "1978-07-08 05:08:00",
+   "start_date": "1978-07-01 00:00:00",
    "station_long_name": "Kennaook/Cape Grim, Tasmania, Australia",
    "version": "testv1"
   },
@@ -1985,7 +1985,7 @@
    "product_type": "mole fraction",
    "site_code": "CGO",
    "species": "cfc-11",
-   "start_date": "1981-11-30 14:01:00",
+   "start_date": "1981-12-01 00:00:00",
    "station_long_name": "Kennaook/Cape Grim, Tasmania, Australia",
    "version": "testv1"
   },
@@ -2102,7 +2102,7 @@
    "data_owner": "Paul Krummel",
    "data_owner_email": "paul.krummel@csiro.au",
    "doi": "",
-   "end_date": "1994-12-29 22:41:00",
+   "end_date": "1994-12-01 00:00:00",
    "frequency": "monthly baseline",
    "inlet_base_elevation_masl": "94.0",
    "inlet_comment": "",
@@ -2121,7 +2121,7 @@
    "product_type": "mole fraction",
    "site_code": "CGO",
    "species": "cfc-11",
-   "start_date": "1978-07-08 09:13:00",
+   "start_date": "1978-07-01 00:00:00",
    "station_long_name": "Kennaook/Cape Grim, Tasmania, Australia",
    "version": "testv1"
   },
@@ -2439,7 +2439,7 @@
    "product_type": "mole fraction",
    "site_code": "CGO",
    "species": "cfc-113",
-   "start_date": "1981-11-30 14:01:00",
+   "start_date": "1982-06-01 21:08:00",
    "station_long_name": "Kennaook/Cape Grim, Tasmania, Australia",
    "version": "testv1"
   },
@@ -2627,7 +2627,7 @@
    "product_type": "mole fraction",
    "site_code": "CGO",
    "species": "cfc-113",
-   "start_date": "1981-11-30 14:01:00",
+   "start_date": "1982-06-01 00:00:00",
    "station_long_name": "Kennaook/Cape Grim, Tasmania, Australia",
    "version": "testv1"
   },
@@ -2744,7 +2744,7 @@
    "data_owner": "Paul Krummel",
    "data_owner_email": "paul.krummel@csiro.au",
    "doi": "",
-   "end_date": "1994-12-29 22:41:00",
+   "end_date": "1994-12-01 00:00:00",
    "frequency": "monthly baseline",
    "inlet_base_elevation_masl": "94.0",
    "inlet_comment": "",
@@ -2760,7 +2760,7 @@
    "product_type": "mole fraction",
    "site_code": "CGO",
    "species": "cfc-113",
-   "start_date": "1982-06-01 21:08:00",
+   "start_date": "1982-06-01 00:00:00",
    "station_long_name": "Kennaook/Cape Grim, Tasmania, Australia",
    "version": "testv1"
   },
@@ -3212,7 +3212,7 @@
    "product_type": "mole fraction",
    "site_code": "CGO",
    "species": "cfc-12",
-   "start_date": "1981-11-30 14:01:00",
+   "start_date": "1981-12-01 10:25:00",
    "station_long_name": "Kennaook/Cape Grim, Tasmania, Australia",
    "version": "testv1"
   },
@@ -3456,7 +3456,7 @@
    "product_type": "mole fraction",
    "site_code": "CGO",
    "species": "cfc-12",
-   "start_date": "1978-07-08 05:08:00",
+   "start_date": "1978-07-01 00:00:00",
    "station_long_name": "Kennaook/Cape Grim, Tasmania, Australia",
    "version": "testv1"
   },
@@ -3589,7 +3589,7 @@
    "product_type": "mole fraction",
    "site_code": "CGO",
    "species": "cfc-12",
-   "start_date": "1981-11-30 14:01:00",
+   "start_date": "1981-12-01 00:00:00",
    "station_long_name": "Kennaook/Cape Grim, Tasmania, Australia",
    "version": "testv1"
   },
@@ -3706,7 +3706,7 @@
    "data_owner": "Paul Krummel",
    "data_owner_email": "paul.krummel@csiro.au",
    "doi": "",
-   "end_date": "1994-12-29 22:41:00",
+   "end_date": "1994-12-01 00:00:00",
    "frequency": "monthly baseline",
    "inlet_base_elevation_masl": "94.0",
    "inlet_comment": "",
@@ -3725,7 +3725,7 @@
    "product_type": "mole fraction",
    "site_code": "CGO",
    "species": "cfc-12",
-   "start_date": "1978-07-08 05:08:00",
+   "start_date": "1978-07-01 00:00:00",
    "station_long_name": "Kennaook/Cape Grim, Tasmania, Australia",
    "version": "testv1"
   },
@@ -3857,7 +3857,7 @@
    "product_type": "mole fraction",
    "site_code": "MHD",
    "species": "ch2cl2",
-   "start_date": "1994-10-13 23:54:00",
+   "start_date": "1995-04-06 23:56:00",
    "station_long_name": "Mace Head, Ireland",
    "version": "testv1"
   },
@@ -4044,7 +4044,7 @@
    "product_type": "mole fraction",
    "site_code": "MHD",
    "species": "ch2cl2",
-   "start_date": "1994-10-13 23:54:00",
+   "start_date": "1995-04-06 23:56:00",
    "station_long_name": "Mace Head, Ireland",
    "version": "testv1"
   },
@@ -4232,7 +4232,7 @@
    "product_type": "mole fraction",
    "site_code": "MHD",
    "species": "ch2cl2",
-   "start_date": "1994-10-13 23:54:00",
+   "start_date": "1995-04-01 00:00:00",
    "station_long_name": "Mace Head, Ireland",
    "version": "testv1"
   },
@@ -4365,7 +4365,7 @@
    "product_type": "mole fraction",
    "site_code": "MHD",
    "species": "ch2cl2",
-   "start_date": "1994-10-13 23:54:00",
+   "start_date": "1995-04-01 00:00:00",
    "station_long_name": "Mace Head, Ireland",
    "version": "testv1"
   },
@@ -4695,7 +4695,7 @@
    "product_type": "mole fraction",
    "site_code": "CGO",
    "species": "ch3ccl3",
-   "start_date": "1978-07-08 05:08:00",
+   "start_date": "1978-07-08 09:13:00",
    "station_long_name": "Kennaook/Cape Grim, Tasmania, Australia",
    "version": "testv1"
   },
@@ -4826,7 +4826,7 @@
    "product_type": "mole fraction",
    "site_code": "CGO",
    "species": "ch3ccl3",
-   "start_date": "1981-11-30 14:01:00",
+   "start_date": "1981-12-01 10:25:00",
    "station_long_name": "Kennaook/Cape Grim, Tasmania, Australia",
    "version": "testv1"
   },
@@ -5443,7 +5443,7 @@
    "product_type": "mole fraction",
    "site_code": "CGO",
    "species": "ch3ccl3",
-   "start_date": "1978-07-08 05:08:00",
+   "start_date": "1978-07-01 00:00:00",
    "station_long_name": "Kennaook/Cape Grim, Tasmania, Australia",
    "version": "testv1"
   },
@@ -5576,7 +5576,7 @@
    "product_type": "mole fraction",
    "site_code": "CGO",
    "species": "ch3ccl3",
-   "start_date": "1981-11-30 14:01:00",
+   "start_date": "1981-12-01 00:00:00",
    "station_long_name": "Kennaook/Cape Grim, Tasmania, Australia",
    "version": "testv1"
   },
@@ -5709,7 +5709,7 @@
    "product_type": "mole fraction",
    "site_code": "CGO",
    "species": "ch3ccl3",
-   "start_date": "1995-01-01 01:16:00",
+   "start_date": "1995-01-01 00:00:00",
    "station_long_name": "Kennaook/Cape Grim, Tasmania, Australia",
    "version": "testv1"
   },
@@ -5845,7 +5845,7 @@
    "product_type": "mole fraction",
    "site_code": "CGO",
    "species": "ch3ccl3",
-   "start_date": "2020-01-01 10:01:00",
+   "start_date": "2020-01-01 00:00:00",
    "station_long_name": "Kennaook/Cape Grim, Tasmania, Australia",
    "version": "testv1"
   },
@@ -5962,7 +5962,7 @@
    "data_owner": "Paul Krummel",
    "data_owner_email": "paul.krummel@csiro.au",
    "doi": "",
-   "end_date": "2021-01-01 22:50:00",
+   "end_date": "2021-01-01 00:00:00",
    "frequency": "monthly baseline",
    "inlet_base_elevation_masl": "94.000000",
    "inlet_comment": "multiple inlets have been used at the station, all in close proximity to each other.",
@@ -5990,7 +5990,7 @@
    "product_type": "mole fraction",
    "site_code": "CGO",
    "species": "ch3ccl3",
-   "start_date": "1978-07-08 09:13:00",
+   "start_date": "1978-07-01 00:00:00",
    "station_long_name": "Kennaook/Cape Grim, Tasmania, Australia",
    "version": "testv1"
   },
@@ -6257,7 +6257,7 @@
    "station_long_name": "Tacolneston, United Kingdom",
    "version": "testv1"
   },
-  "data_checksum": "9e1d0f085cb8b3e57904032065cf8833f741e892915765dcb67658ae11e41162",
+  "data_checksum": "443156fb93fca86db0b78f6d0ae627cae744b8829fa187e38817b38078b9ec68",
   "n_time": 210,
   "type": "netcdf",
   "variables": {
@@ -6388,7 +6388,7 @@
    "station_long_name": "Trinidad Head, California",
    "version": "testv1"
   },
-  "data_checksum": "5cd670ed9044f63e246c34d59c35df6a1af2a306084d1a110656309d5e2c3231",
+  "data_checksum": "3b9aca5a41663795242c11d0d109a11d90486e0aa1b9eee633243e55ec9faf7c",
   "n_time": 25,
   "type": "netcdf",
   "variables": {
@@ -6678,7 +6678,7 @@
    "product_type": "mole fraction",
    "site_code": "CGO",
    "species": "ch4",
-   "start_date": "1981-11-30 14:01:00",
+   "start_date": "1986-05-13 03:54:00",
    "station_long_name": "Kennaook/Cape Grim, Tasmania, Australia",
    "version": "testv1"
   },
@@ -6813,7 +6813,7 @@
    "station_long_name": "Tacolneston, United Kingdom",
    "version": "testv1"
   },
-  "data_checksum": "9e1d0f085cb8b3e57904032065cf8833f741e892915765dcb67658ae11e41162",
+  "data_checksum": "443156fb93fca86db0b78f6d0ae627cae744b8829fa187e38817b38078b9ec68",
   "n_time": 210,
   "type": "netcdf",
   "variables": {
@@ -6944,7 +6944,7 @@
    "station_long_name": "Trinidad Head, California",
    "version": "testv1"
   },
-  "data_checksum": "5cd670ed9044f63e246c34d59c35df6a1af2a306084d1a110656309d5e2c3231",
+  "data_checksum": "3b9aca5a41663795242c11d0d109a11d90486e0aa1b9eee633243e55ec9faf7c",
   "n_time": 25,
   "type": "netcdf",
   "variables": {
@@ -7236,7 +7236,7 @@
    "product_type": "mole fraction",
    "site_code": "CGO",
    "species": "ch4",
-   "start_date": "1981-11-30 14:01:00",
+   "start_date": "1986-05-01 00:00:00",
    "station_long_name": "Kennaook/Cape Grim, Tasmania, Australia",
    "version": "testv1"
   },
@@ -7373,7 +7373,7 @@
    "station_long_name": "Tacolneston, United Kingdom",
    "version": "testv1"
   },
-  "data_checksum": "df9c9e49f3affac7ef49add92b167a0ad9819c0d0f773df5aa3ad436df180f8e",
+  "data_checksum": "8ecdefd419a7767109b99e371709d8c8a34db52e55ae86a56d72f888a755b3c3",
   "n_time": 1,
   "type": "netcdf",
   "variables": {
@@ -7506,7 +7506,7 @@
    "station_long_name": "Trinidad Head, California",
    "version": "testv1"
   },
-  "data_checksum": "63e94faab05e7fdce968c5db3eae1fe4674eb97268923c24e43c434a8d2e4c9b",
+  "data_checksum": "95449c5830beaee546de27e51f7922b6c79523106acdf9fb3150cabef5c115bc",
   "n_time": 1,
   "type": "netcdf",
   "variables": {
@@ -7619,7 +7619,7 @@
    "data_owner": "Paul Krummel",
    "data_owner_email": "paul.krummel@csiro.au",
    "doi": "",
-   "end_date": "1994-12-29 22:41:00",
+   "end_date": "1994-12-01 00:00:00",
    "frequency": "monthly baseline",
    "inlet_base_elevation_masl": "94.0",
    "inlet_comment": "",
@@ -7635,7 +7635,7 @@
    "product_type": "mole fraction",
    "site_code": "CGO",
    "species": "ch4",
-   "start_date": "1986-05-13 03:54:00",
+   "start_date": "1986-05-01 00:00:00",
    "station_long_name": "Kennaook/Cape Grim, Tasmania, Australia",
    "version": "testv1"
   },
@@ -7772,7 +7772,7 @@
    "station_long_name": "Tacolneston, United Kingdom",
    "version": "testv1"
   },
-  "data_checksum": "df9c9e49f3affac7ef49add92b167a0ad9819c0d0f773df5aa3ad436df180f8e",
+  "data_checksum": "8ecdefd419a7767109b99e371709d8c8a34db52e55ae86a56d72f888a755b3c3",
   "n_time": 1,
   "type": "netcdf",
   "variables": {
@@ -7905,7 +7905,7 @@
    "station_long_name": "Trinidad Head, California",
    "version": "testv1"
   },
-  "data_checksum": "63e94faab05e7fdce968c5db3eae1fe4674eb97268923c24e43c434a8d2e4c9b",
+  "data_checksum": "95449c5830beaee546de27e51f7922b6c79523106acdf9fb3150cabef5c115bc",
   "n_time": 1,
   "type": "netcdf",
   "variables": {
@@ -8033,7 +8033,7 @@
    "product_type": "mole fraction",
    "site_code": "MHD",
    "species": "chcl3",
-   "start_date": "1994-10-13 23:54:00",
+   "start_date": "1995-04-06 23:56:00",
    "station_long_name": "Mace Head, Ireland",
    "version": "testv1"
   },
@@ -8220,7 +8220,7 @@
    "product_type": "mole fraction",
    "site_code": "MHD",
    "species": "chcl3",
-   "start_date": "1994-10-13 23:54:00",
+   "start_date": "1995-04-06 23:56:00",
    "station_long_name": "Mace Head, Ireland",
    "version": "testv1"
   },
@@ -8408,7 +8408,7 @@
    "product_type": "mole fraction",
    "site_code": "MHD",
    "species": "chcl3",
-   "start_date": "1994-10-13 23:54:00",
+   "start_date": "1995-04-01 00:00:00",
    "station_long_name": "Mace Head, Ireland",
    "version": "testv1"
   },
@@ -8541,7 +8541,7 @@
    "product_type": "mole fraction",
    "site_code": "MHD",
    "species": "chcl3",
-   "start_date": "1994-10-13 23:54:00",
+   "start_date": "1995-04-01 00:00:00",
    "station_long_name": "Mace Head, Ireland",
    "version": "testv1"
   },
@@ -9048,7 +9048,7 @@
    "product_type": "mole fraction",
    "site_code": "MHD",
    "species": "h-1211",
-   "start_date": "1994-10-13 23:54:00",
+   "start_date": "1994-10-01 00:00:00",
    "station_long_name": "Mace Head, Ireland",
    "version": "testv1"
   },
@@ -9181,7 +9181,7 @@
    "product_type": "mole fraction",
    "site_code": "MHD",
    "species": "h-1211",
-   "start_date": "1994-10-13 23:54:00",
+   "start_date": "1994-10-01 00:00:00",
    "station_long_name": "Mace Head, Ireland",
    "version": "testv1"
   },
@@ -9313,7 +9313,7 @@
    "product_type": "mole fraction",
    "site_code": "MHD",
    "species": "hcfc-141b",
-   "start_date": "1994-10-13 23:54:00",
+   "start_date": "1994-11-03 15:42:00",
    "station_long_name": "Mace Head, Ireland",
    "version": "testv1"
   },
@@ -9500,7 +9500,7 @@
    "product_type": "mole fraction",
    "site_code": "MHD",
    "species": "hcfc-141b",
-   "start_date": "1994-10-13 23:54:00",
+   "start_date": "1994-11-03 15:42:00",
    "station_long_name": "Mace Head, Ireland",
    "version": "testv1"
   },
@@ -9688,7 +9688,7 @@
    "product_type": "mole fraction",
    "site_code": "MHD",
    "species": "hcfc-141b",
-   "start_date": "1994-10-13 23:54:00",
+   "start_date": "1994-11-01 00:00:00",
    "station_long_name": "Mace Head, Ireland",
    "version": "testv1"
   },
@@ -9821,7 +9821,7 @@
    "product_type": "mole fraction",
    "site_code": "MHD",
    "species": "hcfc-141b",
-   "start_date": "1994-10-13 23:54:00",
+   "start_date": "1994-11-01 00:00:00",
    "station_long_name": "Mace Head, Ireland",
    "version": "testv1"
   },
@@ -10328,7 +10328,7 @@
    "product_type": "mole fraction",
    "site_code": "MHD",
    "species": "hcfc-142b",
-   "start_date": "1994-10-13 23:54:00",
+   "start_date": "1994-10-01 00:00:00",
    "station_long_name": "Mace Head, Ireland",
    "version": "testv1"
   },
@@ -10461,7 +10461,7 @@
    "product_type": "mole fraction",
    "site_code": "MHD",
    "species": "hcfc-142b",
-   "start_date": "1994-10-13 23:54:00",
+   "start_date": "1994-10-01 00:00:00",
    "station_long_name": "Mace Head, Ireland",
    "version": "testv1"
   },
@@ -10968,7 +10968,7 @@
    "product_type": "mole fraction",
    "site_code": "MHD",
    "species": "hfc-134a",
-   "start_date": "1994-10-13 23:54:00",
+   "start_date": "1994-10-01 00:00:00",
    "station_long_name": "Mace Head, Ireland",
    "version": "testv1"
   },
@@ -11101,7 +11101,7 @@
    "product_type": "mole fraction",
    "site_code": "MHD",
    "species": "hfc-134a",
-   "start_date": "1994-10-13 23:54:00",
+   "start_date": "1994-10-01 00:00:00",
    "station_long_name": "Mace Head, Ireland",
    "version": "testv1"
   },
@@ -11608,7 +11608,7 @@
    "product_type": "mole fraction",
    "site_code": "MHD",
    "species": "hfc-152a",
-   "start_date": "1994-10-13 23:54:00",
+   "start_date": "1994-10-01 00:00:00",
    "station_long_name": "Mace Head, Ireland",
    "version": "testv1"
   },
@@ -11741,7 +11741,7 @@
    "product_type": "mole fraction",
    "site_code": "MHD",
    "species": "hfc-152a",
-   "start_date": "1994-10-13 23:54:00",
+   "start_date": "1994-10-01 00:00:00",
    "station_long_name": "Mace Head, Ireland",
    "version": "testv1"
   },
@@ -12062,7 +12062,7 @@
    "product_type": "mole fraction",
    "site_code": "CGO",
    "species": "n2o",
-   "start_date": "1978-07-08 05:08:00",
+   "start_date": "1978-07-08 17:30:00",
    "station_long_name": "Kennaook/Cape Grim, Tasmania, Australia",
    "version": "testv1"
   },
@@ -12193,7 +12193,7 @@
    "product_type": "mole fraction",
    "site_code": "CGO",
    "species": "n2o",
-   "start_date": "1981-11-30 14:01:00",
+   "start_date": "1981-12-01 10:25:00",
    "station_long_name": "Kennaook/Cape Grim, Tasmania, Australia",
    "version": "testv1"
   },
@@ -12437,7 +12437,7 @@
    "product_type": "mole fraction",
    "site_code": "CGO",
    "species": "n2o",
-   "start_date": "1978-07-08 05:08:00",
+   "start_date": "1978-07-01 00:00:00",
    "station_long_name": "Kennaook/Cape Grim, Tasmania, Australia",
    "version": "testv1"
   },
@@ -12570,7 +12570,7 @@
    "product_type": "mole fraction",
    "site_code": "CGO",
    "species": "n2o",
-   "start_date": "1981-11-30 14:01:00",
+   "start_date": "1981-12-01 00:00:00",
    "station_long_name": "Kennaook/Cape Grim, Tasmania, Australia",
    "version": "testv1"
   },
@@ -12687,7 +12687,7 @@
    "data_owner": "Paul Krummel",
    "data_owner_email": "paul.krummel@csiro.au",
    "doi": "",
-   "end_date": "1994-12-29 22:41:00",
+   "end_date": "1994-12-01 00:00:00",
    "frequency": "monthly baseline",
    "inlet_base_elevation_masl": "94.0",
    "inlet_comment": "",
@@ -12706,7 +12706,7 @@
    "product_type": "mole fraction",
    "site_code": "CGO",
    "species": "n2o",
-   "start_date": "1978-07-08 17:30:00",
+   "start_date": "1978-07-01 00:00:00",
    "station_long_name": "Kennaook/Cape Grim, Tasmania, Australia",
    "version": "testv1"
   },
@@ -12838,7 +12838,7 @@
    "product_type": "mole fraction",
    "site_code": "MHD",
    "species": "nf3",
-   "start_date": "2020-01-01 00:31:00",
+   "start_date": "2020-01-03 00:40:00",
    "station_long_name": "Mace Head, Ireland",
    "version": "testv1"
   },
@@ -13023,7 +13023,7 @@
    "product_type": "mole fraction",
    "site_code": "MHD",
    "species": "nf3",
-   "start_date": "2020-01-01 00:31:00",
+   "start_date": "2020-01-03 00:40:00",
    "station_long_name": "Mace Head, Ireland",
    "version": "testv1"
   },
@@ -13209,7 +13209,7 @@
    "product_type": "mole fraction",
    "site_code": "MHD",
    "species": "nf3",
-   "start_date": "2020-01-01 00:31:00",
+   "start_date": "2020-01-01 00:00:00",
    "station_long_name": "Mace Head, Ireland",
    "version": "testv1"
   },
@@ -13342,7 +13342,7 @@
    "product_type": "mole fraction",
    "site_code": "MHD",
    "species": "nf3",
-   "start_date": "2020-01-01 00:31:00",
+   "start_date": "2020-01-01 00:00:00",
    "station_long_name": "Mace Head, Ireland",
    "version": "testv1"
   },

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -229,6 +229,29 @@ def test_read_nc_sorts_non_monotonic_timestamps():
     assert pd.Index(ds.time.values).is_monotonic_increasing
 
 
+def test_output_dataset_recomputes_start_date(monkeypatch):
+    ds = xr.Dataset(
+        {"mf": ("time", [1.0, 2.0])},
+        coords={"time": pd.date_range("2020-01-01", periods=2, freq="D")},
+        attrs={
+            "network": "agage_test",
+            "species": "ch4",
+            "site_code": "THD",
+            "version": "testv1",
+            "start_date": "1900-01-01 00:00:00",
+            "end_date": "1900-01-02 00:00:00",
+        },
+    )
+    written = {}
+    monkeypatch.setattr(
+        "agage_archive.io.output_write",
+        lambda dataset, *args, **kwargs: written.setdefault("dataset", dataset),
+    )
+    output_dataset(ds, "agage_test", output_subpath="ch4", verbose=False)
+
+    assert written["dataset"].attrs["start_date"] == "2020-01-01 00:00:00"
+
+
 def test_picarro():
     """Test that Picarro file is read correctly, resampled to hourly and that the timestamp is at the beginning of the sampling period
     """


### PR DESCRIPTION
## Summary
- recompute `start_date` and `end_date` in `output_dataset` after final filtering
- add a regression test for stale source `start_date`
- update STATUS and CHANGELOG with the approved output-format decision
- regenerate the golden manifest to capture the intentional corrected attributes

## Tests
- `conda run -n agage python -m pytest -q tests/test_io.py -k test_output_dataset_recomputes_start_date` (1 passed)
- `AGAGE_UPDATE_MANIFEST=1 conda run -n agage python -m pytest -q tests/test_archive.py` (archive test passed after manifest regeneration)
- Full suite before manifest regeneration: 69 passed, 1 failed due to expected B12 manifest differences

The manifest update is intentional and approved in the STATUS decisions log. The remaining full-suite baseline mismatch should be rechecked from this branch after review.