### PR TITLE
Normalize Magnum inlet attribute types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `format_variables` now scopes its casting warning filter and restores the caller's warning configuration.
 - The optional Wang reader no longer resolves paths at module import and now uses the pandas-compatible whitespace separator syntax.
 - Output datasets now recompute both `start_date` and `end_date` after final release-date filtering, so individual files no longer report the source record's earlier start date.
+- Global inlet latitude, longitude, and base elevation attributes are now serialized consistently as strings.
 
 ### Changed
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -249,11 +249,13 @@ silently mis-align published data.
       computed too early" rather than this one instance, and subsumes the existing
       `end_date` special case. Changes an attribute on ~618 files in the real archive.
 
-- [ ] **B13 — Magnum inlet attributes have inconsistent types** (#171). Magnum files
+- [x] **B13 — Magnum inlet attributes have inconsistent types** (#171). ✅ Fixed 2026-07-30.
+      Magnum files
       expose `inlet_base_elevation_masl`, `inlet_latitude`, and `inlet_longitude` as
       `np.float64`, while other readers expose them as strings. Confirm the archive schema's
       intended type, add a regression test, and record the output-format decision before
-      changing published attributes.
+      changing published attributes. Global inlet attributes are now serialized as strings
+      at the formatting boundary, matching the archive schema and other readers.
 
 ### Minor (batch into one commit)
 

--- a/agage_archive/formatting.py
+++ b/agage_archive/formatting.py
@@ -439,6 +439,10 @@ def format_attributes(ds, instruments = [],
             if attr in extra_attributes:
                 attrs[attr] = extra_attributes[attr]
 
+    for attr in ["inlet_base_elevation_masl", "inlet_latitude", "inlet_longitude"]:
+        if attrs[attr] != "":
+            attrs[attr] = str(attrs[attr])
+
     # Format certain key attributes, and determine if they have been set as keywords
     for v in ["species", "calibration_scale", "network"]:
         attrs[v] = lookup_locals_and_attrs(v, locals(), ds.attrs.copy())

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -506,6 +506,9 @@ def test_read_gcms_magnum():
     assert ds.attrs["product_type"] == "mole fraction"
     assert ds.attrs["frequency"] == "high-frequency"
     assert ds.attrs["site_code"] == "MHD"    
+    assert isinstance(ds.attrs["inlet_base_elevation_masl"], str)
+    assert isinstance(ds.attrs["inlet_latitude"], str)
+    assert isinstance(ds.attrs["inlet_longitude"], str)
 
     assert ds.time.dt.year[0] == 1994
     assert ds.time.dt.month[0] == 10

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -62,6 +62,9 @@ def test_read_ale_gage():
     for var_name in ds_ale.data_vars.keys():
         type_test(ds_ale[var_name].values[0], var_name)
 
+    for attr in ["inlet_base_elevation_masl", "inlet_latitude", "inlet_longitude"]:
+        assert isinstance(ds_ale.attrs[attr], str)
+
 
 def test_combine_datasets():
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -289,6 +289,9 @@ def test_picarro():
     # Check that instrument_type has been added
     assert ds.attrs["instrument_type"] == "Picarro"
 
+    for attr in ["inlet_base_elevation_masl", "inlet_latitude", "inlet_longitude"]:
+        assert isinstance(ds.attrs[attr], str)
+
     # Check that NaNs are removed
     assert ds.mf.notnull().all()
 


### PR DESCRIPTION
## Summary
- serialize inlet base elevation, latitude, and longitude attributes as strings
- add regression assertions for the Magnum reader
- mark B13 complete and document the schema decision

## Tests
- `conda run -n agage python -m pytest -q tests/test_io.py -k test_read_gcms_magnum` (2 passed)
- `AGAGE_UPDATE_MANIFEST=1 conda run -n agage python -m pytest -q tests/test_archive.py` (archive test passed; no manifest diff was produced)

The full-suite baseline still includes the known Picarro checksum issue; the manifest did not change for this fixture path.