### PR TITLE
Raise clear errors for missing ZIP members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The optional Wang reader no longer resolves paths at module import and now uses the pandas-compatible whitespace separator syntax.
 - Output datasets now recompute both `start_date` and `end_date` after final release-date filtering, so individual files no longer report the source record's earlier start date.
 - Global inlet latitude, longitude, and base elevation attributes are now serialized consistently as strings.
+- Missing ZIP members now raise `FileNotFoundError` instead of an unrelated `IndexError`.
 
 ### Changed
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -259,8 +259,9 @@ silently mis-align published data.
 
 ### Minor (batch into one commit)
 
-- [ ] `fnmatch.filter` shadows the builtin and raises `IndexError` rather than
-      `FileNotFoundError` on no match — [config.py:384](agage_archive/config.py#L384)
+- [x] `fnmatch.filter` shadows the builtin and raises `IndexError` rather than
+      `FileNotFoundError` on no match. ✅ Fixed 2026-07-30. ZIP member lookup now raises
+      `FileNotFoundError` with the requested member name.
 - [ ] `open_data_file` returns a handle from a closed `ZipFile`; works only via
       `ZipExtFile` refcounting
 - [ ] Leading-slash zip member when `output_subpath=""` — [io.py:1402](agage_archive/io.py#L1402)

--- a/agage_archive/config.py
+++ b/agage_archive/config.py
@@ -2,7 +2,7 @@ from pathlib import Path as _Path
 import tarfile
 from zipfile import ZipFile, ZIP_DEFLATED
 import yaml
-from fnmatch import fnmatch, filter
+from fnmatch import fnmatch
 import psutil
 from shutil import copy, rmtree
 import os
@@ -391,7 +391,10 @@ def open_data_file(filename,
 
     if pth.suffix == ".zip":
         with ZipFile(pth, mode) as z:
-            return z.open(filter(z.namelist(), filename)[0])
+            matches = [member for member in z.namelist() if fnmatch(member, filename)]
+            if not matches:
+                raise FileNotFoundError(f"Can't find {filename} in {pth}")
+            return z.open(matches[0])
     elif "tar.gz" in filename:
         return tarfile.open(pth / filename, f"{mode}:gz")
     else:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -187,4 +187,9 @@ def test_invalid_error_mode_raises_value_error():
 
 def test_raise_mode_checks_missing_directory_file():
     with pytest.raises(FileNotFoundError, match="missing.txt"):
-        data_file_path("missing.txt", "agage_test", "path_test_files", errors="raise")
+                data_file_path("missing.txt", "agage_test", "path_test_files", errors="raise")
+
+
+def test_open_data_file_missing_zip_member_raises():
+    with pytest.raises(FileNotFoundError, match="missing.txt"):
+        open_data_file("missing.txt", "agage_test", "path_test_files/A.zip")

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -358,7 +358,7 @@ def test_read_gcwerks_flask():
 
     # Check that some attributes that are only in site attributes have been added
     assert "sampling_period" in ds.attrs.keys()
-    assert ds.attrs["inlet_latitude"] == 2
+    assert ds.attrs["inlet_latitude"] == "2"
 
     # Test flask_pair_agreement parameter
     ds_default = read_gcwerks_flask("agage_test", "cf4", "CBW", "GCMS-Medusa-flask",


### PR DESCRIPTION
## Summary
- remove the shadowed `fnmatch.filter` import
- raise a descriptive `FileNotFoundError` when a ZIP member is absent
- add regression coverage for missing ZIP members
- update the stale flask inlet-type assertion to match the merged B13 invariant
- mark the minor missing-member item complete in STATUS

Addresses #38

## Tests
- `conda run -n agage python -m pytest -q tests/test_config.py` (11 passed)
- Full suite before the stale assertion correction: 70 passed, 1 failed; the failure was the existing flask test expecting numeric inlet latitude after B13 changed the archive-wide invariant to strings.
- `git diff --check` passed.