### PR TITLE
Normalize ZIP output member paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Output datasets now recompute both `start_date` and `end_date` after final release-date filtering, so individual files no longer report the source record's earlier start date.
 - Global inlet latitude, longitude, and base elevation attributes are now serialized consistently as strings.
 - Missing ZIP members now raise `FileNotFoundError` instead of an unrelated `IndexError`.
+- ZIP output paths no longer create a leading slash when `output_subpath` is empty.
 
 ### Changed
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -264,7 +264,8 @@ silently mis-align published data.
       `FileNotFoundError` with the requested member name.
 - [ ] `open_data_file` returns a handle from a closed `ZipFile`; works only via
       `ZipExtFile` refcounting
-- [ ] Leading-slash zip member when `output_subpath=""` — [io.py:1402](agage_archive/io.py#L1402)
+- [x] Leading-slash zip member when `output_subpath=""`. ✅ Fixed 2026-07-30. ZIP output
+      now normalizes empty or slash-terminated subpaths without creating a leading slash.
 - [ ] Zip `"a"` mode creates duplicate members if a run is not preceded by `delete_archive`
 - [ ] `if "time" in var` should be `var == "time"` — [data_selection.py:269](agage_archive/data_selection.py#L269)
 - [ ] Instrument partial-matching uses dict insertion order, not longest match —

--- a/agage_archive/io.py
+++ b/agage_archive/io.py
@@ -1435,7 +1435,9 @@ def output_write(ds, out_path, filename,
     # Write file
     if out_path.suffix == ".zip":
         with ZipFile(out_path, mode="a", compression=ZIP_DEFLATED, compresslevel=6) as zip:
-            zip.writestr(output_subpath + "/" + filename, ds.to_netcdf())
+            member_path = "/".join(part for part in output_subpath.split("/") if part)
+            member_path = f"{member_path}/{filename}" if member_path else filename
+            zip.writestr(member_path, ds.to_netcdf())
     
     else:
         # Test if output_path exists and if not create it


### PR DESCRIPTION
## Summary
- normalize empty and slash-terminated `output_subpath` values before writing ZIP members
- prevent leading-slash archive members
- mark the corresponding minor STATUS item complete

Addresses #38

## Tests
- `git diff --check` passed
- Existing ZIP read/config tests remain covered; output ZIP integration coverage is still part of the outstanding ZIP-path test work.