### PR TITLE
Replace duplicate ZIP output members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Global inlet latitude, longitude, and base elevation attributes are now serialized consistently as strings.
 - Missing ZIP members now raise `FileNotFoundError` instead of an unrelated `IndexError`.
 - ZIP output paths no longer create a leading slash when `output_subpath` is empty.
+- ZIP output writes now replace an existing member instead of creating duplicate members.
 
 ### Changed
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -266,7 +266,8 @@ silently mis-align published data.
       `ZipExtFile` refcounting
 - [x] Leading-slash zip member when `output_subpath=""`. ✅ Fixed 2026-07-30. ZIP output
       now normalizes empty or slash-terminated subpaths without creating a leading slash.
-- [ ] Zip `"a"` mode creates duplicate members if a run is not preceded by `delete_archive`
+- [x] Zip `"a"` mode creates duplicate members if a run is not preceded by `delete_archive`. ✅ Fixed
+      2026-07-30. Existing members are replaced when writing the same archive path.
 - [ ] `if "time" in var` should be `var == "time"` — [data_selection.py:269](agage_archive/data_selection.py#L269)
 - [ ] Instrument partial-matching uses dict insertion order, not longest match —
       [definitions.py:165-170](agage_archive/definitions.py#L165-L170)

--- a/agage_archive/io.py
+++ b/agage_archive/io.py
@@ -1437,6 +1437,15 @@ def output_write(ds, out_path, filename,
         with ZipFile(out_path, mode="a", compression=ZIP_DEFLATED, compresslevel=6) as zip:
             member_path = "/".join(part for part in output_subpath.split("/") if part)
             member_path = f"{member_path}/{filename}" if member_path else filename
+            if member_path in zip.namelist():
+                source_members = [member for member in zip.infolist() if member.filename != member_path]
+                existing_data = {member.filename: zip.read(member) for member in source_members}
+                zip.close()
+                with ZipFile(out_path, mode="w", compression=ZIP_DEFLATED, compresslevel=6) as replacement:
+                    for name, data in existing_data.items():
+                        replacement.writestr(name, data)
+                    replacement.writestr(member_path, ds.to_netcdf())
+                return
             zip.writestr(member_path, ds.to_netcdf())
     
     else:

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -9,7 +9,7 @@ from agage_archive.config import Paths, open_data_file
 from agage_archive.io import read_ale_gage, read_nc, combine_datasets, read_nc_path, \
     read_baseline, combine_baseline, output_dataset, read_gcwerks_flask, drop_duplicates, \
     read_gcms_magnum_file, read_gcms_magnum, define_instrument_type, get_data_read_function, \
-    _merge_duplicate_flask_measurements
+    _merge_duplicate_flask_measurements, output_write
 from agage_archive.convert import scale_convert
 from agage_archive.definitions import instrument_type_definition, get_instrument_number
 from agage_archive.data_selection import read_data_combination
@@ -253,6 +253,18 @@ def test_output_dataset_recomputes_start_date(monkeypatch):
     output_dataset(ds, "agage_test", output_subpath="ch4", verbose=False)
 
     assert written["dataset"].attrs["start_date"] == "2020-01-01 00:00:00"
+
+
+def test_output_write_replaces_existing_zip_member(tmp_path):
+    from zipfile import ZipFile
+
+    ds = xr.Dataset({"mf": ("time", [1.0])}, coords={"time": [0]})
+    archive = tmp_path / "output.zip"
+    output_write(ds, archive, "file.nc", output_subpath="species")
+    output_write(ds, archive, "file.nc", output_subpath="species")
+
+    with ZipFile(archive) as zip_file:
+        assert zip_file.namelist().count("species/file.nc") == 1
 
 
 def test_picarro():


### PR DESCRIPTION
## Summary
- replace an existing ZIP member when the same output path is written again
- add regression coverage for repeated writes without `delete_archive`
- mark the duplicate-member STATUS item complete

Addresses #38

## Tests
- `conda run -n agage python -m pytest -q tests/test_config.py tests/test_io.py -k "zip or output_write"` (2 passed)
- `conda run -n agage python -m pytest -q` (72 passed, 1 warning)
- `git diff --check` passed.