### PR TITLE
Match only the time coordinate in exclusions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Missing ZIP members now raise `FileNotFoundError` instead of an unrelated `IndexError`.
 - ZIP output paths no longer create a leading slash when `output_subpath` is empty.
 - ZIP output writes now replace an existing member instead of creating duplicate members.
+- Data-exclusion processing now only skips the actual `time` coordinate, not variables whose names merely contain `time`.
 
 ### Changed
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -268,7 +268,8 @@ silently mis-align published data.
       now normalizes empty or slash-terminated subpaths without creating a leading slash.
 - [x] Zip `"a"` mode creates duplicate members if a run is not preceded by `delete_archive`. ✅ Fixed
       2026-07-30. Existing members are replaced when writing the same archive path.
-- [ ] `if "time" in var` should be `var == "time"` — [data_selection.py:269](agage_archive/data_selection.py#L269)
+- [x] `if "time" in var` should be `var == "time"`. ✅ Fixed 2026-07-30. Variables whose
+      names contain `time` are now processed normally during exclusions.
 - [ ] Instrument partial-matching uses dict insertion order, not longest match —
       [definitions.py:165-170](agage_archive/definitions.py#L165-L170)
 - [ ] `choose_scale_defaults_file` breaks ties using `data_file_list` order, which is

--- a/agage_archive/data_selection.py
+++ b/agage_archive/data_selection.py
@@ -311,7 +311,7 @@ def read_data_exclude(ds, species, site, instrument,
         for start, end in data_exclude.values:
             exclude_dict = dict(time = slice(start, end))
             for var in ds.variables:
-                if "time" in var:
+                if var == "time":
                     continue
                 elif variable_defaults[var]["remove_flagged"] == "True":
                     ds[var].loc[exclude_dict] = np.nan


### PR DESCRIPTION
## Summary
- check for the exact `time` coordinate instead of substring matches
- prevent variables with names containing `time` from being skipped during exclusions
- mark the minor STATUS item complete

Addresses #38

## Tests
- `conda run -n agage python -m pytest -q tests/test_data_selection.py -k test_read_data_exclude` (1 passed)
- `git diff --check` passed.