### PR TITLE
Prefer longest instrument partial match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ZIP output paths no longer create a leading slash when `output_subpath` is empty.
 - ZIP output writes now replace an existing member instead of creating duplicate members.
 - Data-exclusion processing now only skips the actual `time` coordinate, not variables whose names merely contain `time`.
+- Instrument partial matching now prefers the longest matching instrument name.
 
 ### Changed
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -270,8 +270,8 @@ silently mis-align published data.
       2026-07-30. Existing members are replaced when writing the same archive path.
 - [x] `if "time" in var` should be `var == "time"`. ✅ Fixed 2026-07-30. Variables whose
       names contain `time` are now processed normally during exclusions.
-- [ ] Instrument partial-matching uses dict insertion order, not longest match —
-      [definitions.py:165-170](agage_archive/definitions.py#L165-L170)
+- [x] Instrument partial-matching uses dict insertion order, not longest match. ✅ Fixed
+      2026-07-30. Partial matches now prefer the longest instrument name.
 - [ ] `choose_scale_defaults_file` breaks ties using `data_file_list` order, which is
       filesystem glob order. Not currently triggered (only one file matches any given
       instrument/site), but it is the same class of non-determinism fixed in Phase 0a —

--- a/agage_archive/definitions.py
+++ b/agage_archive/definitions.py
@@ -167,7 +167,7 @@ def get_instrument_number(instrument, network):
         instrument_type = instrument_number[instrument]
     else:
         # If not, try to find a partial match (e.g., Picarro-1 -> Picarro)
-        for k, v in instrument_number.items():
+        for k, v in sorted(instrument_number.items(), key=lambda item: len(item[0]), reverse=True):
             if k in instrument:
                 instrument_type = v
                 break

--- a/tests/test_definitions.py
+++ b/tests/test_definitions.py
@@ -69,6 +69,7 @@ def test_get_instrument_number():
     instrument_num = get_instrument_number("Picarro-1", network)
     assert isinstance(instrument_num, int)
     assert instrument_num == instrument_number["Picarro"]
+    assert get_instrument_number("GCMS-Medusa-flask", network) == instrument_number["GCMS-Medusa-flask"]
 
     instrument_number_with_overlap = {"GCMS": 1, "GCMS-Medusa": 2}
     monkeypatch = pytest.MonkeyPatch()

--- a/tests/test_definitions.py
+++ b/tests/test_definitions.py
@@ -69,3 +69,12 @@ def test_get_instrument_number():
     instrument_num = get_instrument_number("Picarro-1", network)
     assert isinstance(instrument_num, int)
     assert instrument_num == instrument_number["Picarro"]
+
+    instrument_number_with_overlap = {"GCMS": 1, "GCMS-Medusa": 2}
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(
+        "agage_archive.definitions.define_instrument_number",
+        lambda network: instrument_number_with_overlap,
+    )
+    assert get_instrument_number("GCMS-Medusa-flask", network) == 2
+    monkeypatch.undo()


### PR DESCRIPTION
## Summary
- prefer the longest matching instrument name during partial lookup
- add regression coverage for overlapping instrument names
- verify exact configured types still take precedence over partial matching
- mark the STATUS item complete

## Why longest match?
Concrete instrument names can contain multiple instrument-type names. For example, `GCMS-Medusa-flask` matches both `GCMS` and `GCMS-Medusa`. The longer match is the more specific fallback, so it should resolve to `GCMS-Medusa` rather than the generic `GCMS` when no exact type is configured.

Exact matches still win first. Therefore, when `GCMS-Medusa-flask` is present as a configured instrument type, it resolves to itself, while a concrete variant such as `Picarro-1` falls back to `Picarro`. The tests cover both behaviors.

The broader design question of replacing substring inference with explicit aliases is tracked separately in #197.

## Tests
- `conda run -n agage python -m pytest -q tests/test_definitions.py` (4 passed)
- `git diff --check` passed.