### PR TITLE
Make scale default selection deterministic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ZIP output writes now replace an existing member instead of creating duplicate members.
 - Data-exclusion processing now only skips the actual `time` coordinate, not variables whose names merely contain `time`.
 - Instrument partial matching now prefers the longest matching instrument name.
+- Scale-default file selection now breaks equal-specificity ties by filename rather than filesystem order.
 
 ### Changed
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -272,10 +272,8 @@ silently mis-align published data.
       names contain `time` are now processed normally during exclusions.
 - [x] Instrument partial-matching uses dict insertion order, not longest match. ✅ Fixed
       2026-07-30. Partial matches now prefer the longest instrument name.
-- [ ] `choose_scale_defaults_file` breaks ties using `data_file_list` order, which is
-      filesystem glob order. Not currently triggered (only one file matches any given
-      instrument/site), but it is the same class of non-determinism fixed in Phase 0a —
-      [data_selection.py:155-171](agage_archive/data_selection.py#L155-L171)
+- [x] `choose_scale_defaults_file` broke ties using `data_file_list` order, which is
+      filesystem glob order. ✅ Fixed 2026-07-30. Ties now use a stable filename sort.
 - [ ] `site_code` casing differs between readers: `read_nc` upper-cases
       ([io.py:261](agage_archive/io.py#L261)), `read_ale_gage`
       ([io.py:634](agage_archive/io.py#L634)) and `read_gcwerks_flask`

--- a/agage_archive/data_selection.py
+++ b/agage_archive/data_selection.py
@@ -198,7 +198,10 @@ def choose_scale_defaults_file(network, instrument, site=""):
     
     # Split the file name into parts, separated by '-'
     # Sort by the length of the parts, so that more specific files are checked first
-    scale_defaults_files_sorted = sorted(scale_defaults_files, key=lambda x: len(x.split("_")), reverse=True)
+    scale_defaults_files_sorted = sorted(
+        scale_defaults_files,
+        key=lambda x: (-len(x.split("_")), x),
+    )
 
     for file in scale_defaults_files_sorted:
         filename_parts = file.split(".")[0].split("_")

--- a/tests/test_data_selection.py
+++ b/tests/test_data_selection.py
@@ -23,6 +23,17 @@ def test_choose_scale_defaults_file():
     assert choose_scale_defaults_file("agage_test", "test") == "defaults_test"
 
 
+def test_choose_scale_defaults_file_tie_break_is_stable():
+    files = [
+        "scale_defaults_test_cgo.csv",
+        "scale_defaults_test_mhd.csv",
+        "scale_defaults_test.csv",
+    ]
+    with patch("agage_archive.data_selection.data_file_list",
+               return_value=("agage_test", "", files)):
+        assert choose_scale_defaults_file("agage_test", "test", site="CGO") == "defaults_test_cgo"
+
+
 def test_calibration_scale_defaults():
     '''Test calibration_scale_default function'''
 


### PR DESCRIPTION
## Summary
- make equal-specificity scale-default matches sort by filename
- remove filesystem-order dependence from `choose_scale_defaults_file`
- add regression coverage and mark the STATUS item complete

Addresses #38

## Tests
- `conda run -n agage python -m pytest -q tests/test_data_selection.py -k choose_scale` (2 passed)
- `git diff --check` passed.