### PR TITLE
Keep ZIP archive open for returned member handle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Data-exclusion processing now only skips the actual `time` coordinate, not variables whose names merely contain `time`.
 - Instrument partial matching now prefers the longest matching instrument name.
 - Scale-default file selection now breaks equal-specificity ties by filename rather than filesystem order.
+- `open_data_file` now keeps a ZIP archive open for the lifetime of the member handle it returns and closes it when that handle is closed, instead of closing the archive first and relying on CPython's `ZipExtFile` reference counting to keep the closed archive readable.
 
 ### Changed
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -5,7 +5,7 @@ Working plan for the code-quality pass on `agage-archive`. Read
 structure must not change.
 
 **Started:** 2026-07-28
-**Last updated:** 2026-07-30
+**Last updated:** 2026-07-30 (open_data_file ZIP handle lifetime)
 
 Update the checkboxes and the "Last updated" date as items land. Keep the findings
 register at the bottom in sync — if an item turns out to be a non-issue, mark it
@@ -262,8 +262,11 @@ silently mis-align published data.
 - [x] `fnmatch.filter` shadows the builtin and raises `IndexError` rather than
       `FileNotFoundError` on no match. ✅ Fixed 2026-07-30. ZIP member lookup now raises
       `FileNotFoundError` with the requested member name.
-- [ ] `open_data_file` returns a handle from a closed `ZipFile`; works only via
-      `ZipExtFile` refcounting
+- [x] `open_data_file` returns a handle from a closed `ZipFile`; works only via
+      `ZipExtFile` refcounting. ✅ Fixed 2026-07-30. The archive is now kept open for the
+      returned handle's lifetime and closed deterministically when the handle is closed;
+      output is unchanged. Regression test asserts the backing `ZipFile` is open while the
+      handle is live.
 - [x] Leading-slash zip member when `output_subpath=""`. ✅ Fixed 2026-07-30. ZIP output
       now normalizes empty or slash-terminated subpaths without creating a leading slash.
 - [x] Zip `"a"` mode creates duplicate members if a run is not preceded by `delete_archive`. ✅ Fixed

--- a/agage_archive/config.py
+++ b/agage_archive/config.py
@@ -390,11 +390,28 @@ def open_data_file(filename,
         print(f"... opening {pth / filename}")
 
     if pth.suffix == ".zip":
-        with ZipFile(pth, mode) as z:
+        # Do not use a `with` block here: closing the ZipFile before returning
+        # would leave the member handle reading from a closed archive, which
+        # only works by accident via CPython's ZipExtFile reference counting.
+        # Keep the ZipFile open for the lifetime of the handle, and close it
+        # when the handle is closed so the underlying file is released promptly.
+        z = ZipFile(pth, mode)
+        try:
             matches = [member for member in z.namelist() if fnmatch(member, filename)]
             if not matches:
                 raise FileNotFoundError(f"Can't find {filename} in {pth}")
-            return z.open(matches[0])
+            handle = z.open(matches[0])
+        except Exception:
+            z.close()
+            raise
+        handle_close = handle.close
+        def _close(_handle_close=handle_close, _z=z):
+            try:
+                _handle_close()
+            finally:
+                _z.close()
+        handle.close = _close
+        return handle
     elif "tar.gz" in filename:
         return tarfile.open(pth / filename, f"{mode}:gz")
     else:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -193,3 +193,35 @@ def test_raise_mode_checks_missing_directory_file():
 def test_open_data_file_missing_zip_member_raises():
     with pytest.raises(FileNotFoundError, match="missing.txt"):
         open_data_file("missing.txt", "agage_test", "path_test_files/A.zip")
+
+
+def _backing_zipfile(handle):
+    """Return the ZipFile that backs a ZipExtFile returned by open_data_file.
+
+    The member handle keeps its archive alive through the ZipFile._fpclose
+    bound method stored on its shared file object; this reaches it so a test can
+    assert the archive is still open.
+    """
+    return handle._fileobj._close.__self__
+
+
+def test_open_data_file_zip_handle_keeps_archive_open():
+    """The returned zip member handle must not read from a closed archive.
+
+    Regression test: previously the ZipFile was closed before returning, so the
+    handle only stayed readable by accident via CPython's ZipExtFile reference
+    counting. The archive must stay open for the handle's lifetime and be closed
+    when the handle is closed.
+    """
+    handle = open_data_file("B/C.txt", "agage_test", "path_test_files/A.zip")
+    try:
+        zipf = _backing_zipfile(handle)
+        assert zipf.fp is not None, "backing ZipFile was closed while handle live"
+        # The handle is fully usable, including random access.
+        assert handle.read().decode("utf-8") == "test"
+        handle.seek(0)
+        assert handle.read().decode("utf-8") == "test"
+    finally:
+        handle.close()
+    # Closing the handle deterministically closes the archive (no GC needed).
+    assert zipf.fp is None


### PR DESCRIPTION
## Summary

Fixes the "Minor" Phase 1 item in `STATUS.md`: *`open_data_file` returns a handle from a closed `ZipFile`; works only via `ZipExtFile` refcounting.*

`open_data_file` opened a ZIP inside `with ZipFile(pth, mode) as z:` and returned `z.open(member)` — so the `ZipFile` was closed the instant the function returned. The member handle stayed readable only because CPython's `ZipExtFile` keeps the underlying file object alive through `_fileRefCnt`, i.e. it was reading from a conceptually closed archive. I confirmed this directly: on the old code the backing `ZipFile.fp` is `None` (closed) while the returned handle is still being read.

## Change

`agage_archive/config.py` now:
- keeps the `ZipFile` open for the lifetime of the returned handle, and
- wraps the handle's `close` so closing the handle (including via `with`) also closes the archive, releasing the underlying file **deterministically** — no reliance on GC timing or the refcount trick.
- On a missing member it still raises `FileNotFoundError`, now closing the archive first so no descriptor leaks.

## Behaviour verified

- Backing `ZipFile` is open while the handle is live; `read()` and `seek()` work.
- `handle.close()` closes the archive immediately (no GC needed).
- 50 `with open_data_file(...)` iterations leak **zero** file descriptors.
- Missing-member error raises and leaks no descriptor.

## Output impact

None. The full golden-manifest suite (`tests/test_archive.py`) passes byte-for-byte — this is an internal lifetime fix, not an output change.

## Tests

- Added `test_open_data_file_zip_handle_keeps_archive_open` (asserts the backing `ZipFile` is open while the handle is live and closed once the handle is closed). It **fails on the old code** (`backing ZipFile was closed while handle live`) and passes on the fix.
- Full suite: **74 passed** in ~106s (`agage` conda env). The one warning is a pre-existing numpy binary-compat notice, unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)