### PR TITLE
Fix inconsistent site_code casing across readers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Instrument partial matching now prefers the longest matching instrument name.
 - Scale-default file selection now breaks equal-specificity ties by filename rather than filesystem order.
 - `open_data_file` now keeps a ZIP archive open for the lifetime of the member handle it returns and closes it when that handle is closed, instead of closing the archive first and relying on CPython's `ZipExtFile` reference counting to keep the closed archive readable.
+- `read_ale_gage`, `read_gcms_magnum` and `read_gcwerks_flask` now upper-case `site_code` in output attributes, matching `read_nc` and `read_baseline`. Previously they stored the raw `site` argument, so a differently-cased site code would silently fail the case-sensitive `attributes_site.json` lookup in `format_attributes`, dropping station metadata with no error.
 
 ### Changed
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -5,7 +5,7 @@ Working plan for the code-quality pass on `agage-archive`. Read
 structure must not change.
 
 **Started:** 2026-07-28
-**Last updated:** 2026-07-30 (open_data_file ZIP handle lifetime)
+**Last updated:** 2026-07-30 (site_code casing consistency)
 
 Update the checkboxes and the "Last updated" date as items land. Keep the findings
 register at the bottom in sync — if an item turns out to be a non-issue, mark it
@@ -277,11 +277,13 @@ silently mis-align published data.
       2026-07-30. Partial matches now prefer the longest instrument name.
 - [x] `choose_scale_defaults_file` broke ties using `data_file_list` order, which is
       filesystem glob order. ✅ Fixed 2026-07-30. Ties now use a stable filename sort.
-- [ ] `site_code` casing differs between readers: `read_nc` upper-cases
-      ([io.py:261](agage_archive/io.py#L261)), `read_ale_gage`
-      ([io.py:634](agage_archive/io.py#L634)) and `read_gcwerks_flask`
-      ([io.py:1093](agage_archive/io.py#L1093)) do not — so a lowercase site code silently
-      skips `attributes_site.json` lookup for ALE/GAGE
+- [x] `site_code` casing differs between readers. ✅ Fixed 2026-07-30. `read_nc` and
+      `read_baseline` already upper-cased `site_code`; `read_ale_gage`, `read_gcms_magnum`
+      and `read_gcwerks_flask` stored the raw `site` argument instead, so a lowercase or
+      mixed-case site code would silently fail the `attributes_site.json` lookup in
+      `format_attributes` (dict keys are upper-case) with no error. All readers now
+      upper-case `site_code` consistently; no effect on the fixture, whose site codes are
+      already upper-case.
 
 ---
 

--- a/agage_archive/io.py
+++ b/agage_archive/io.py
@@ -634,7 +634,7 @@ def read_ale_gage(network, species, site, instrument,
                 "inlet_latitude": site_info[site]["latitude"],
                 "inlet_longitude": site_info[site]["longitude"],
                 "inlet_comment": "",
-                "site_code": site,
+                "site_code": site.upper(),
                 "product_type": "mole fraction",
                 "instrument_selection": "Individual instruments",
                 "frequency": "high-frequency",}
@@ -917,7 +917,7 @@ def read_gcms_magnum(network, species,
     extra_attrs["instrument_selection"] = "Individual instruments"
     extra_attrs["frequency"] = "high-frequency"
     extra_attrs["instrument_type"] = get_instrument_type(get_instrument_number(instrument, network), network)
-    extra_attrs["site_code"] = site
+    extra_attrs["site_code"] = site.upper()
 
     # Add attributes
     ds = format_attributes(ds,
@@ -1093,7 +1093,7 @@ def read_gcwerks_flask(network, species, site, instrument,
         coords={"time": xr.coding.times.decode_cf_datetime(ds_raw["sample_time"].values - sampling_period/2,
                                                            units="seconds since 1970-01-01")},
         attrs={"comment": f"GCMS Medusa flask data for {species_search} at {site_info['station_long_name']}.",
-               "site_code": site}
+               "site_code": site.upper()}
     )
 
     # Sort by sampling time

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -66,6 +66,42 @@ def test_read_ale_gage():
         assert isinstance(ds_ale.attrs[attr], str)
 
 
+def test_read_ale_gage_site_code_uppercased():
+    """A lowercase site code must still end up as the canonical upper-case
+    form in output attributes, even though it is looked up in
+    ale_gage_sites.json under a lowercase alias here. Otherwise a
+    differently-cased site argument would silently produce a differently-cased
+    site_code, which feeds directly into the output filename."""
+
+    with open_data_file("ale_gage_sites.json", network="agage_test") as f:
+        site_info = json.load(f)
+    site_info["cgo"] = site_info["CGO"]
+
+    with open_data_file("ale_gage_timestamp_issues.json", network="agage_test") as f:
+        timestamp_issues = json.load(f)
+    timestamp_issues["ALE"]["cgo"] = timestamp_issues["ALE"]["CGO"]
+
+    real_open_data_file = open_data_file
+
+    def fake_open_data_file(filename, *args, **kwargs):
+        if filename == "ale_gage_sites.json":
+            return BytesIO(json.dumps(site_info).encode())
+        if filename == "ale_gage_timestamp_issues.json":
+            return BytesIO(json.dumps(timestamp_issues).encode())
+        return real_open_data_file(filename, *args, **kwargs)
+
+    # read_release_schedule does its own case-sensitive site lookup, which is
+    # out of scope here (tracked separately); skip it to isolate the site_code fix.
+    # tz_local_to_utc (in util.py) does its own ale_gage_sites.json lookup too.
+    with patch("agage_archive.io.open_data_file", side_effect=fake_open_data_file), \
+         patch("agage_archive.util.open_data_file", side_effect=fake_open_data_file), \
+         patch("agage_archive.io.read_release_schedule", return_value=None):
+        ds = read_ale_gage("agage_test", "ch3ccl3", "cgo", "ALE",
+                           data_exclude=False, dropna=False)
+
+    assert ds.attrs["site_code"] == "CGO"
+
+
 def test_combine_datasets():
 
     network = "agage_test"
@@ -386,6 +422,39 @@ def test_read_gcwerks_flask():
     assert len(ds_filtered.time) == len(ds_default.time) - 1
 
 
+def test_read_gcwerks_flask_site_code_uppercased():
+    """A lowercase site code (looked up here under a lowercase alias in
+    attributes_site.json) must still produce the canonical upper-case
+    site_code. Before this was fixed, a lowercase site_code would silently
+    fail the case-sensitive attributes_site.json lookup inside
+    format_attributes, dropping station metadata such as
+    station_long_name/inlet_latitude without any error."""
+
+    with open_data_file("attributes_site.json", network="agage_test") as f:
+        site_info_all = json.load(f)
+    site_info_all["cbw"] = site_info_all["CBW"]
+
+    real_open_data_file = open_data_file
+
+    def fake_open_data_file(filename, *args, **kwargs):
+        if filename == "attributes_site.json":
+            return BytesIO(json.dumps(site_info_all).encode())
+        return real_open_data_file(filename, *args, **kwargs)
+
+    # read_release_schedule and read_data_exclude do their own case-sensitive
+    # site lookups, which are out of scope here (tracked separately); skip
+    # them to isolate the site_code fix.
+    with patch("agage_archive.io.open_data_file", side_effect=fake_open_data_file), \
+         patch("agage_archive.formatting.open_data_file", side_effect=fake_open_data_file), \
+         patch("agage_archive.io.read_release_schedule", return_value=None):
+        ds = read_gcwerks_flask("agage_test", "cf4", "cbw", "GCMS-Medusa-flask",
+                                data_exclude=False)
+
+    assert ds.attrs["site_code"] == "CBW"
+    assert ds.attrs["station_long_name"] == "Cabauw (NL)"
+    assert ds.attrs["inlet_latitude"] == "2"
+
+
 def test_merge_duplicate_flask_measurements():
 
     time = pd.to_datetime([
@@ -523,7 +592,7 @@ def test_read_gcms_magnum():
     assert ds.attrs["instrument_type"] == "GCMS-Magnum"
     assert ds.attrs["product_type"] == "mole fraction"
     assert ds.attrs["frequency"] == "high-frequency"
-    assert ds.attrs["site_code"] == "MHD"    
+    assert ds.attrs["site_code"] == "MHD"
     assert isinstance(ds.attrs["inlet_base_elevation_masl"], str)
     assert isinstance(ds.attrs["inlet_latitude"], str)
     assert isinstance(ds.attrs["inlet_longitude"], str)
@@ -533,7 +602,7 @@ def test_read_gcms_magnum():
     assert ds.time.dt.day[0] == 13
     assert ds.time.dt.hour[0] == 23
     assert ds.time.dt.hour[0] == 23
-    assert ds.time.dt.minute[0] == 54        
+    assert ds.time.dt.minute[0] == 54
 
     # Release schedule says that the last year should be 1998
     assert ds.time.dt.year[-1] == 1998
@@ -541,6 +610,32 @@ def test_read_gcms_magnum():
     assert np.isclose(ds.mf.values[0], 9.303)
 
     assert ds.sampling_period.values[0] == 2400
+
+
+def test_read_gcms_magnum_site_code_uppercased():
+    """Same as test_read_ale_gage_site_code_uppercased: a lowercase site
+    argument (looked up here under a lowercase alias in ale_gage_sites.json)
+    must still produce the canonical upper-case site_code."""
+
+    with open_data_file("ale_gage_sites.json", network="agage_test") as f:
+        site_info = json.load(f)
+    site_info["mhd"] = site_info["MHD"]
+
+    real_open_data_file = open_data_file
+
+    def fake_open_data_file(filename, *args, **kwargs):
+        if filename == "ale_gage_sites.json":
+            return BytesIO(json.dumps(site_info).encode())
+        return real_open_data_file(filename, *args, **kwargs)
+
+    # read_release_schedule does its own case-sensitive site lookup, which is
+    # out of scope here (tracked separately); skip it to isolate the site_code fix.
+    with patch("agage_archive.io.open_data_file", side_effect=fake_open_data_file), \
+         patch("agage_archive.io.read_release_schedule", return_value=None):
+        ds = read_gcms_magnum("agage_test", "hfc-134a", site="mhd",
+                             data_exclude=False, dropna=True)
+
+    assert ds.attrs["site_code"] == "MHD"
 
 
 def test_define_instrument_type():


### PR DESCRIPTION
## Summary

- `read_ale_gage`, `read_gcms_magnum` and `read_gcwerks_flask` stored the raw `site` argument in the `site_code` output attribute, unlike `read_nc` and `read_baseline`, which already upper-case it.
- `attributes_site.json` is keyed by upper-case site code, so a differently-cased `site_code` silently failed the lookup in `format_attributes` and dropped station metadata (e.g. `station_long_name`, `inlet_latitude`) with no error.
- `site_code` also feeds directly into the output filename via `output_dataset`/`output_path`, so a casing mismatch there would have changed published filenames.
- All three readers now upper-case `site_code` consistently, closing the last item in STATUS.md's "minor" batch.

Output is unchanged: the `agage_test` fixture's site codes are already upper-case everywhere, so this only guards against future/real-network inputs.

## Test plan

- [x] Added `test_read_ale_gage_site_code_uppercased`, `test_read_gcms_magnum_site_code_uppercased`, `test_read_gcwerks_flask_site_code_uppercased` in `tests/test_io.py`, each feeding a lowercase site code through the reader (via a lowercase-keyed alias injected into the relevant JSON fixture) and asserting `site_code` comes back upper-case. The flask test additionally asserts that station metadata (`station_long_name`, `inlet_latitude`) is correctly merged in, demonstrating the silent-skip failure mode this closes.
- [x] Full suite: `python -m pytest -q` — 77 passed, golden manifest unaffected (byte-identical output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)