### PR TITLE
Add T1 unit tests for run.py control flow

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -5,7 +5,7 @@ Working plan for the code-quality pass on `agage-archive`. Read
 structure must not change.
 
 **Started:** 2026-07-28
-**Last updated:** 2026-07-30 (run_all/combine_datasets structure review — P6, S6)
+**Last updated:** 2026-07-30 (T1 run.py tests done; run_all/combine_datasets review — P6, S6)
 
 Update the checkboxes and the "Last updated" date as items land. Keep the findings
 register at the bottom in sync — if an item turns out to be a non-issue, mark it
@@ -331,11 +331,15 @@ modulo the three volatile attributes.
 
 ## Phase 3 — Test coverage
 
-- [ ] **T1 — `run.py` unit tests** (29% → target 80%): the release-schedule `"x"` skip; the
-      `top_level_only` conflict raise ([run.py:146](agage_archive/run.py#L146)); the
-      single-instrument early return ([run.py:168](agage_archive/run.py#L168)); and the
-      error-log path — deliberately break one species and assert it lands in the log with a
-      useful message.
+- [x] **T1 — `run.py` unit tests** (29% → 87%, target 80%). ✅ Done 2026-07-30 in
+      [tests/test_run.py](tests/test_run.py). Covers the release-schedule `"x"` skip; the
+      unknown-species skip in `run_individual_instrument`; the single-instrument promotion
+      to the top-level directory; the early-return deferral when a combined file already
+      owns the top-level slot (`cfc-113` at CGO); the `top_level_only` conflict raise; the
+      error-log path (a broken species is logged with its site/species/message while a
+      healthy one in the same call is not); and the `run_all` isinstance validation wall
+      (S3). Written ahead of S6, so that refactor can be checked against intended behaviour
+      rather than only the byte-level manifest.
 - [x] **T2 — Timestamp-mismatch tests** for `run_timestamp_checks` covering B2 and B3.
       ✅ Done 2026-07-29 in [tests/test_run.py](tests/test_run.py), along with targeted
       tests for the determinism fixes, `data_combination_species`, the contested

--- a/STATUS.md
+++ b/STATUS.md
@@ -5,7 +5,7 @@ Working plan for the code-quality pass on `agage-archive`. Read
 structure must not change.
 
 **Started:** 2026-07-28
-**Last updated:** 2026-07-30 (site_code casing consistency)
+**Last updated:** 2026-07-30 (run_all/combine_datasets structure review — P6, S6)
 
 Update the checkboxes and the "Last updated" date as items land. Keep the findings
 register at the bottom in sync — if an item turns out to be a non-issue, mark it
@@ -310,6 +310,19 @@ best-value work in the plan.
 - [ ] **P5 — Stop calling `format_variables` two or three times per dataset.** It rebuilds
       the whole Dataset and re-reads three JSON files each time (`read_nc`, then
       `combine_datasets`).
+- [ ] **P6 — Cache the raw per-instrument read+resample shared by both workflows.** Every
+      source file is read and resampled once for the individual product
+      (`run_individual_site` → `read_function`) and again for the combined product
+      (`combine_datasets` → `_read_combined_instrument_datasets` → same `read_function`).
+      Cache the raw read+resample keyed on `(network, species, site, instrument)` and let
+      each workflow apply its own downstream transforms. **The two products legitimately
+      diverge *after* the raw read** — the individual file uses the instrument-specific
+      scale (`choose_scale_defaults_file(network, instrument, site)`) while the combined
+      file uses the `"combined"` scale, the combined path applies an extra
+      `read_data_exclude(..., combined=True)` layer, and it slices to the `data_combination`
+      date window — so the cache must sit before scale conversion, the combined exclusion,
+      and windowing, not after. This is a caching change, **not** a merge of the two
+      workflows (see decisions log 2026-07-30).
 
 **Target:** ≥40% reduction in wall time for a full `agage_test` run, byte-identical output
 modulo the three volatile attributes.
@@ -376,6 +389,23 @@ Highest risk to output format — do last, once Phases 0–3 are green.
       readers accept and ignore `**kwargs`.
 - [ ] **S5 — Simplify the `errors=` contract in `config.py`** (see B4/B5), against the T3
       matrix.
+- [ ] **S6 — Collapse the parallelisation residue in `run_all`.** The per-site/per-species
+      split across `run_individual_instrument`/`run_individual_site` and
+      `run_combined_instruments`/`run_combined_site` — each inner function processing one
+      unit of work, returning a `(site, species, error)` tuple, the caller collecting the
+      tuples into a list and reducing it to an error log — is the leftover shape of an
+      abandoned attempt to map the inner function across a worker pool. Serially it is pure
+      indirection: it is why `run_individual_site` must be handed `rs`, `read_function`,
+      `read_baseline_function` and `instrument_out` as arguments instead of deriving them.
+      Simplify the control flow and argument threading. Safe against the golden manifest,
+      which pins output bytes and not call structure, **but gate on T1** — this refactor
+      moves exactly the error-log and `top_level_only`-conflict paths that T1 is meant to
+      cover, so write those tests first.
+
+**Note — the two workflows are deliberately *not* merged.** Reading each source file twice
+(once individual, once combined) is real but the two products differ in scale, exclusions
+and date-windowing, and the real cost is config re-parsing. See decisions log 2026-07-30;
+the shared raw read is addressed by P6, not by a structural merge here.
 
 ---
 
@@ -452,6 +482,7 @@ Record anything that changes the plan, especially anything touching output forma
 | 2026-07-29 | B2 fixed after targeted tests showed the check was not merely weak but completely dead. Enabling it changes no output; it only means a genuine data/baseline mismatch now fails instead of being published. |
 | 2026-07-29 | B12 (`start_date` too early in individual-instrument files) was approved for a later PR. Preferred approach: compute the date attributes at write time in `output_dataset` rather than in each reader. |
 | 2026-07-30 | B12 fix approved for landing: recompute `start_date` and `end_date` in `output_dataset` after final filtering. This intentionally changes published attributes on affected files; regenerate the golden manifest after review. |
+| 2026-07-30 | **Reviewed `run_all`/`combine_datasets` structure.** Two issues confirmed. (1) The per-site/per-species split and `(site, species, error)` tuple threading in `run_all` and the `run_*_instruments` functions is residue from an abandoned parallelisation attempt — added as S6 (Phase 4, gated on T1). (2) Each source file is read twice (individual + combined workflows), but the two products legitimately differ (instrument-specific vs `"combined"` scale, the extra `combined=True` exclusion, `data_combination` date-windowing) and the dominant cost is config re-parsing, not raw I/O. **Merging the two workflows was considered and rejected** — high output-risk for little gain, and it would also have to preserve the combined-before-individual ordering that the top-level-file existing check depends on. The genuinely shared work (raw read+resample, before the products diverge) is captured as a caching item, P6 (Phase 2), not a structural merge. |
 | 2026-07-29 | **Contested top-level files now raise.** If more than one instrument is eligible to write `{species}/` because the species has no row in the site's `data_combination` file, processing fails with an error naming the species and site, rather than letting run order decide. Sites in the real archive have already been corrected by hand; this makes a regression impossible to miss. |
 
 ### Open questions

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -12,7 +12,8 @@ import xarray as xr
 
 import agage_archive.run
 from agage_archive.data_selection import data_combination_species, read_data_combination
-from agage_archive.run import run_individual_instrument, run_timestamp_checks
+from agage_archive.run import run_all, run_combined_instruments, \
+    run_individual_instrument, run_timestamp_checks
 
 
 NETWORK = "agage_test"
@@ -231,3 +232,182 @@ def test_flask_with_baseline_produces_mole_fractions(clean_output, error_log_tex
     # Baseline products are skipped rather than half-written
     assert not list(clean_output.rglob("baseline-flags/*.nc"))
     assert not list(clean_output.rglob("monthly-baseline/*.nc"))
+
+
+# T1: run.py control flow
+# =======================
+#
+# These pin the branches of the individual/combined orchestration that the golden manifest
+# only exercises as a side effect: the release-schedule "x" skip, single- vs multi-instrument
+# folder choice, the top_level_only guard, and the error-log path. They exist so that the
+# Phase 4 (S6) rewrite of this control flow — which removes the leftover per-site/per-species
+# split and the (site, species, error) tuple threading — can be checked against the intended
+# behaviour rather than only against the byte-level manifest.
+
+
+def test_release_schedule_x_is_skipped(clean_output, error_log_text):
+    """A cell marked "x" means "process no part of this record": no file, no error.
+
+    ALE measures cfc-11 only at CGO in the fixture; every other site, including SMO, is
+    marked x. Processing SMO must produce nothing at all and must not be treated as a
+    failure.
+    """
+
+    run_individual_instrument(NETWORK, "ALE", species=["cfc-11"], sites=["SMO"],
+                              baseline="", monthly=False)
+
+    assert error_log_text() == ""
+    assert not list(clean_output.rglob("*.nc"))
+
+
+def test_unknown_species_for_instrument_is_skipped(clean_output, error_log_text):
+    """A species absent from the instrument's release schedule is skipped cleanly.
+
+    hfc-134a is a GCMS-Magnum species and has no row in the ALE schedule, so
+    run_individual_instrument has nothing to process and must return without writing a
+    file or an error.
+    """
+
+    run_individual_instrument(NETWORK, "ALE", species=["hfc-134a"], sites=["CGO"],
+                              baseline="", monthly=False)
+
+    assert error_log_text() == ""
+    assert not list(clean_output.rglob("*.nc"))
+
+
+def test_single_instrument_is_promoted_to_top_level(clean_output, error_log_text):
+    """One instrument and no data_combination entry: the file is also the recommended file.
+
+    nf3 at MHD is measured only by GCMS-Medusa, and MHD has no data_combination file, so
+    read_data_combination returns a single default instrument. The individual file is then
+    written both to individual-instruments/ and, as the recommended record, to the
+    top-level nf3/ directory (with no instrument in its name).
+    """
+
+    run_individual_instrument(NETWORK, "GCMS-Medusa", species=["nf3"], sites=["MHD"],
+                              baseline="", monthly=False)
+
+    assert error_log_text() == ""
+
+    top_level = list((clean_output / "nf3").glob("agage_test_mhd_nf3_*.nc"))
+    individual = list((clean_output / "nf3" / "individual-instruments").glob(
+        "agage_test-gcms-medusa_mhd_nf3_*.nc"))
+
+    assert top_level, "single-instrument file was not promoted to the top-level directory"
+    assert individual, "individual-instruments file was not written"
+
+
+def test_top_level_only_conflicts_with_multiple_instruments(clean_output, error_log_text):
+    """top_level_only is incompatible with a species that has a combined record.
+
+    ch3ccl3 at CGO is measured by four instruments and has a data_combination entry, so a
+    combined file owns the top-level slot. Asking an individual instrument to write only
+    the top-level file for it is a contradiction and must be reported, naming the species
+    and site.
+    """
+
+    run_individual_instrument(NETWORK, "GCMD", species=["ch3ccl3"], sites=["CGO"],
+                              baseline="", monthly=False, top_level_only=True)
+
+    errors = error_log_text()
+
+    assert "top_level_only is set to True" in errors
+    assert "ch3ccl3" in errors and "CGO" in errors
+
+
+def test_individual_instrument_defers_to_combined_top_level(monkeypatch, clean_output,
+                                                            error_log_text):
+    """When a combined file owns the top-level slot, the individual run must not rewrite it.
+
+    cfc-113 at CGO is a single-instrument (GAGE) species that nonetheless has a
+    data_combination entry, which marks it as the recommended record. Once the combined
+    workflow has written the top-level file, run_individual_site takes the early-return
+    path and writes only its individual-instruments file, leaving the top-level file to
+    the combined product.
+    """
+
+    run_combined_instruments(NETWORK, species=["cfc-113"], sites=["CGO"],
+                             baseline=False, monthly=False)
+    assert error_log_text() == ""
+    assert list((clean_output / "cfc-113").glob("agage_test_cgo_cfc-113_*.nc"))
+
+    real_output_dataset = agage_archive.run.output_dataset
+    written_subpaths = []
+
+    def spy(ds, network, output_subpath="", **kwargs):
+        written_subpaths.append(output_subpath)
+        return real_output_dataset(ds, network, output_subpath=output_subpath, **kwargs)
+
+    monkeypatch.setattr(agage_archive.run, "output_dataset", spy)
+
+    run_individual_instrument(NETWORK, "GAGE", species=["cfc-113"], sites=["CGO"],
+                              baseline="", monthly=False)
+
+    assert error_log_text() == ""
+    # Its own file is written...
+    assert "cfc-113/individual-instruments" in written_subpaths
+    # ...but the top-level file, owned by the combined product, is left untouched.
+    assert "cfc-113" not in written_subpaths
+
+
+def test_read_failure_is_logged_for_that_species_only(monkeypatch, clean_output,
+                                                       error_log_text):
+    """A failure in one species lands in the error log, naming it, and spares the others.
+
+    run_individual_site wraps each species in a broad except that appends to the error
+    log, so a failure is a missing file rather than a crash. Break the read for cfc-11 and
+    confirm it is logged with its site, species and message, while cfc-12 — read through
+    the same instrument in the same call — succeeds and is absent from the log.
+    """
+
+    real_get = agage_archive.run.get_data_read_function
+
+    def failing_get(network, instrument):
+        reader = real_get(network, instrument)
+
+        def wrapper(network, species, site, instrument, **kwargs):
+            if species == "cfc-11":
+                raise ValueError("synthetic read failure")
+            return reader(network, species, site, instrument, **kwargs)
+
+        wrapper.__name__ = reader.__name__
+        return wrapper
+
+    monkeypatch.setattr(agage_archive.run, "get_data_read_function", failing_get)
+
+    run_individual_instrument(NETWORK, "ALE", species=["cfc-11", "cfc-12"], sites=["CGO"],
+                              baseline="", monthly=False)
+
+    errors = error_log_text()
+
+    assert "synthetic read failure" in errors
+    assert "cfc-11" in errors and "CGO" in errors
+    # cfc-12 was read through the same instrument and succeeded
+    assert "cfc-12" not in errors
+
+
+# run_all argument validation
+# ===========================
+#
+# The hand-written isinstance wall in run_all (Phase 4, S3). Cheap to pin because each
+# check raises before any processing or filesystem side effect.
+
+
+def test_run_all_requires_a_network():
+    with pytest.raises(ValueError, match="Must specify network"):
+        run_all("")
+
+
+def test_run_all_rejects_non_string_network():
+    with pytest.raises(TypeError, match="network must be a string"):
+        run_all(123)
+
+
+def test_run_all_rejects_non_list_species():
+    with pytest.raises(TypeError, match="species must be a list"):
+        run_all(NETWORK, species="ch3ccl3")
+
+
+def test_run_all_rejects_non_bool_baseline():
+    with pytest.raises(TypeError, match="baseline must be a boolean"):
+        run_all(NETWORK, baseline="yes")


### PR DESCRIPTION
Implements **T1** from STATUS.md — unit tests for `agage_archive.run`, written ahead of the Phase 4 **S6** rewrite so that refactor can be checked against intended behaviour rather than only the byte-level golden manifest.

## What's covered

New tests in `tests/test_run.py` for the individual/combined orchestration branches:

- **release-schedule `"x"` skip** — a cell marked `x` produces no file and no error (`ALE cfc-11` at SMO)
- **unknown-species skip** — a species absent from the instrument's schedule returns cleanly
- **single-instrument promotion** — one instrument with no `data_combination` entry is written to both `individual-instruments/` and the top-level directory (`GCMS-Medusa nf3` at MHD)
- **early-return deferral** — when the combined workflow already owns the top-level slot, the individual run writes only its `individual-instruments/` file and does not rewrite the top-level file (`cfc-113` at CGO, verified with an `output_dataset` spy)
- **`top_level_only` conflict** — asking for top-level-only output on a multi-instrument species is reported, naming species and site (`GCMD ch3ccl3` at CGO)
- **error-log path** — a broken species lands in the log with its site/species/message, while a healthy species read through the same instrument in the same call is absent
- **`run_all` argument validation** — the hand-written `isinstance` wall (Phase 4 S3 target)

## Results

- `run.py` line coverage **72% → 87%** (T1 target was 80%)
- Full suite green: **87 passed**

STATUS.md updated to mark T1 done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X1HUQQdPf5u3ocNaX8vCe8