### PR TITLE
Cover zip output in the golden manifest test (closes Phase 0)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -5,7 +5,7 @@ Working plan for the code-quality pass on `agage-archive`. Read
 structure must not change.
 
 **Started:** 2026-07-28
-**Last updated:** 2026-07-30 (T1 run.py tests done; run_all/combine_datasets review — P6, S6)
+**Last updated:** 2026-07-30 (Phase 0 closed — golden test now covers zip output)
 
 Update the checkboxes and the "Last updated" date as items land. Keep the findings
 register at the bottom in sync — if an item turns out to be a non-issue, mark it
@@ -84,7 +84,7 @@ would have frozen a ragged, half-broken archive as the reference.
 kinds, writes no error log, and is byte-identical across runs and across
 `PYTHONHASHSEED` values.
 
-## Phase 0 — Safety net (#38) ✅ MOSTLY DONE (2026-07-29)
+## Phase 0 — Safety net (#38) ✅ DONE (2026-07-30)
 
 - [x] **Golden archive manifest test** — `tests/test_archive.py`, reference at
       `tests/reference/archive_manifest.json` (127 entries). Pins per-file paths,
@@ -95,16 +95,25 @@ kinds, writes no error log, and is byte-identical across runs and across
 - [x] **Assert the error logs are empty** — `test_archive_has_no_errors`.
 - [x] **`conftest.py` fixture** isolating `data/agage_test/output`; `test_cf_compliance`
       no longer deletes the output tree as a side effect.
-- [ ] **Run the golden test against zip output as well as directory output.** Still
-      outstanding — these take different code paths through `config.py` and only the
-      directory path is covered. Needs the `errors=` behaviour pinned first (T3/B4/B5),
-      since the zip path is where `data_file_path` returns `None`.
+- [x] **Run the golden test against zip output as well as directory output.** ✅ Done
+      2026-07-30, once its prerequisite (T3/B4/B5) landed. The `archive` fixture in
+      `tests/test_archive.py` is parametrised over `{directory, zip}`: the zip variant
+      redirects `output_path` to `output.zip` by patching the config loader (no change to
+      the user's `config.yaml`), runs the full archive, then extracts the zip and reuses
+      the existing reader. Zip members carry no stem prefix, so the extracted tree and the
+      directory tree compare against the *same* reference manifest. The zip run's output is
+      byte-identical to the directory run — no zip-specific regression — which also
+      exercises the recent zip write-path fixes (member replacement, leading-slash
+      normalisation, kept-open handle) end to end. Both variants are `slow`-marked and
+      independently selectable (`-k zip` / `-k directory`).
 
 **Exit criteria met:** perturbing one character of a `long_name` in `data/variables.json`
 produces 84 manifest differences and fails the suite.
 
-**Suite:** 46 passed, ~2.5 min (the archive test is ~1 min; deselect with `-m "not slow"`).
-**Coverage:** 67% → 73% overall; `run.py` 29% → 72%.
+**Suite:** 89 passed (85 fast + 4 slow), fast tests ~32 s; the archive test now runs the
+full archive twice (directory + zip), ~2.5 min total. Deselect the slow pair with
+`-m "not slow"`.
+**Coverage:** 67% → 77% overall; `run.py` 29% → 87%.
 
 ---
 

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -19,12 +19,15 @@ frozen, and a manifest diff is exactly the thing that needs an explicit decision
 import hashlib
 import json
 import os
+import tempfile
 from pathlib import Path
+from zipfile import ZipFile
 
 import numpy as np
 import pytest
 import xarray as xr
 
+import agage_archive.config
 from agage_archive.config import data_file_path
 from agage_archive.run import run_all
 
@@ -113,30 +116,81 @@ def archive_manifest(root):
     return manifest
 
 
-@pytest.fixture(scope="module")
-def archive():
-    """Run the full archive once and return its manifest, plus any error logs.
+def _patch_config_output(monkeypatch, output_path_value):
+    """Redirect the agage_test output_path for the duration of a run.
+
+    Paths re-reads config.yaml (via yaml.safe_load) on every construction, so patching
+    the loader is the least invasive way to point the output somewhere else without
+    editing the user's config file. The guard leaves any non-config YAML untouched, so
+    only the network's output_path is affected.
+
+    Args:
+        monkeypatch (pytest.MonkeyPatch): Patcher to register the override on.
+        output_path_value (str): Value to substitute for the network's output_path.
+    """
+
+    real_safe_load = agage_archive.config.yaml.safe_load
+
+    def patched(stream):
+        loaded = real_safe_load(stream)
+        try:
+            network_paths = loaded["paths"][NETWORK]
+        except (TypeError, KeyError):
+            return loaded
+        loaded["paths"][NETWORK] = {**network_paths, "output_path": output_path_value}
+        return loaded
+
+    monkeypatch.setattr(agage_archive.config.yaml, "safe_load", patched)
+
+
+@pytest.fixture(scope="module", params=["directory", "zip"])
+def archive(request):
+    """Run the full archive once per output backend and return its manifest + error logs.
+
+    The directory and zip backends take different paths through config.py and io.py
+    (data_file_path, output_write, create_empty_archive, delete_archive); only the
+    directory path was covered before. Running the same golden manifest against zip output
+    pins the zip write path end to end — the path used by the downstream dvc-tracked
+    release repositories. Zip members are stored under their archive path with no stem
+    prefix, so extracting the archive reproduces the exact directory tree and the existing
+    reader compares against the same reference manifest.
 
     Returns:
         tuple[dict, list[str]]: Manifest, and the contents of any error log written.
     """
 
-    out_path = data_file_path("", network=NETWORK, sub_path="output", errors="ignore")
-    out_path.mkdir(parents=True, exist_ok=True)
+    out_dir = data_file_path("", network=NETWORK, sub_path="output", errors="ignore")
+    out_dir.mkdir(parents=True, exist_ok=True)
+    zip_path = out_dir.parent / "output.zip"
 
-    run_all(NETWORK,
-            delete=True,
-            combined=True,
-            baseline=True,
-            monthly=True)
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        if request.param == "zip":
+            _patch_config_output(monkeypatch, "output.zip")
 
-    error_logs = []
-    for name in ("error_log_individual.txt", "error_log_combined.txt"):
-        log = data_file_path(name, network=NETWORK, errors="ignore")
-        if log.exists():
-            error_logs.append(f"{name}:\n{log.read_text()}")
+        run_all(NETWORK,
+                delete=True,
+                combined=True,
+                baseline=True,
+                monthly=True)
 
-    return archive_manifest(out_path), error_logs
+        error_logs = []
+        for name in ("error_log_individual.txt", "error_log_combined.txt"):
+            log = data_file_path(name, network=NETWORK, errors="ignore")
+            if log.exists():
+                error_logs.append(f"{name}:\n{log.read_text()}")
+
+        if request.param == "zip":
+            with tempfile.TemporaryDirectory() as extract_dir:
+                with ZipFile(zip_path, "r") as archive_zip:
+                    archive_zip.extractall(extract_dir)
+                manifest = archive_manifest(extract_dir)
+        else:
+            manifest = archive_manifest(out_dir)
+
+    if request.param == "zip" and zip_path.exists():
+        zip_path.unlink()
+
+    return manifest, error_logs
 
 
 @pytest.mark.slow


### PR DESCRIPTION
Closes the last open item in **Phase 0** (safety net, #38): the golden manifest test now runs against **zip output** as well as directory output.

## Why

`test_archive.py` only exercised directory output. The zip backend takes different code paths through `config.py` and `io.py` (`data_file_path`, `output_write`, `create_empty_archive`, `delete_archive`) and had no end-to-end coverage — and it's the path the downstream dvc-tracked release repositories actually use. The plan gated this on the `errors=` behaviour being pinned first (T3/B4/B5), which is now done.

## What

- Parametrise the module-scoped `archive` fixture over `{directory, zip}`.
- The zip variant redirects `output_path` to `output.zip` by patching the config loader for the run — **the user's `config.yaml` is not touched** — then runs the full archive, extracts the zip to a temp dir, and reuses the existing `archive_manifest` reader.
- Zip members are stored under their archive path with no stem prefix, so the extracted tree reproduces the directory tree exactly and both compare against the **same** reference manifest.
- `output.zip` is removed in teardown (it is not gitignored).

## Result

- Both variants pass; the **zip run's output is byte-identical to the directory run** — no zip-specific regression. This also exercises the recent zip write-path fixes (member replacement, leading-slash normalisation, kept-open handle) end to end.
- Both are `@pytest.mark.slow` and independently selectable (`-k zip` / `-k directory`); the archive test now runs the full archive twice (~2.5 min total). Deselect with `-m "not slow"`.
- Full suite: **89 passed** (85 fast + 4 slow).

STATUS.md updated: Phase 0 marked ✅ DONE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X1HUQQdPf5u3ocNaX8vCe8