### PR TITLE
Cache config, JSON and instrument-number loads (P1-P3)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -5,7 +5,7 @@ Working plan for the code-quality pass on `agage-archive`. Read
 structure must not change.
 
 **Started:** 2026-07-28
-**Last updated:** 2026-07-30 (Phase 0 closed — golden test now covers zip output)
+**Last updated:** 2026-07-30 (P1–P3 caching done)
 
 Update the checkboxes and the "Last updated" date as items land. Keep the findings
 register at the bottom in sync — if an item turns out to be a non-issue, mark it
@@ -301,16 +301,25 @@ silently mis-align published data.
 All of this is provably output-preserving once Phase 0 is in place, which makes it the
 best-value work in the plan.
 
-- [ ] **P1 — Cache config and JSON loads.** `Paths()` walks the tree looking for `.git` and
-      re-parses `config.yaml` on every construction: 373 constructions and 343 YAML parses
-      per `combine_datasets` call, 1.28 s of 5.27 s. Caching *only* the config YAML parse,
-      changing nothing else, measured **2.45 s → 1.87 s (24% faster)** with identical
-      output. Extend to `variables.json`, `attributes.json`, `standard_names.json`,
-      `variables_not_public.json`.
-- [ ] **P2 — Cache `define_instrument_number`.** Re-lists a directory on every call, and is
-      called per-dataset and per-variable via `instrument_type_definition`.
-- [ ] **P3 — Cache `ale_gage_sites.json`.** Read 243 times in a single `combine_datasets`
-      call, once per monthly ALE/GAGE file via `tz_local_to_utc`.
+- [x] **P1 — Cache config and JSON loads.** ✅ Done 2026-07-30. `config.py` now caches the
+      `.git` walk, the `*_archive` package glob and the `config.yaml` parse (keyed on
+      path+mtime), and adds `config.load_json` — a parse memoised by path+mtime that returns
+      a fresh deep copy per call. Copy-on-return is required: `format_attributes` overlays
+      network/site attributes onto `attributes.json` and `read_data_exclude` does
+      `variable_defaults.update(...)` on `variables.json`, so a shared instance would poison
+      the cache. Applied to `variables.json`, `attributes.json`, `standard_names.json`,
+      `variables_not_public.json`. Per cold `combine_datasets` call: config parses **322 → 1**,
+      package glob **357 → 1**, JSON parses **283 → 6**.
+- [x] **P2 — Cache `define_instrument_number`.** ✅ Done 2026-07-30. Memoised on network,
+      returns a fresh dict per call; **22 → 1** directory listings per cold call.
+- [x] **P3 — Cache `ale_gage_sites.json`.** ✅ Done 2026-07-30. The three hot-path reads
+      (`read_ale_gage`, `read_gcms_magnum`, and `tz_local_to_utc`, the last called once per
+      monthly ALE/GAGE file) now go through `load_json`. `io_other_formats.py` reads the
+      same file directly but is off the hot path (0% coverage) and was left untouched.
+
+**Result (P1–P3 together):** `combine_datasets('agage_test','ch3ccl3','CGO')` **2.26 s → 1.90 s
+(16% faster)** on repeated calls, same machine. Golden manifest (directory + zip) byte-identical
+under `PYTHONHASHSEED` 0 and 12345. PR bundles the three as separate commits.
 - [ ] **P4 — Vectorise `drop_duplicates`.** [io.py:87-113](agage_archive/io.py#L87-L113)
       does an O(n) `ds.sel(time=timestamp)` inside a loop over duplicated timestamps.
       Replace with a pandas groupby on `(time, instrument_type)` priority. Cover the

--- a/agage_archive/config.py
+++ b/agage_archive/config.py
@@ -1,14 +1,64 @@
 from pathlib import Path as _Path
+import json
 import tarfile
 from zipfile import ZipFile, ZIP_DEFLATED
 import yaml
+from copy import deepcopy
 from fnmatch import fnmatch
+from functools import lru_cache
 import psutil
 from shutil import copy, rmtree
 import os
 
 
 ERROR_MODES = {"raise", "ignore", "ignore_inputs", "ignore_outputs"}
+
+
+@lru_cache(maxsize=None)
+def _find_working_directory(cwd):
+    """Walk up from cwd to the repository root (the directory holding .git).
+
+    Cached: the repository root does not move within a run, and this walk otherwise runs
+    on every Paths() construction — hundreds of times per combined dataset.
+    """
+
+    working_directory = cwd
+    while True:
+        if (working_directory / ".git").exists():
+            return working_directory
+        working_directory = working_directory.parent
+        if working_directory == _Path("/"):
+            raise FileNotFoundError("Can't find repository root")
+
+
+@lru_cache(maxsize=None)
+def _find_package_root(working_directory):
+    """Find the ``*_archive`` package folder under working_directory. Cached (see above)."""
+
+    for pth in working_directory.glob("*_archive"):
+        if (pth / "__init__.py").exists():
+            return pth
+    raise FileNotFoundError("Can't find package folder. Make sure your package has "
+                            "'_archive' in the folder name and __init__.py")
+
+
+@lru_cache(maxsize=None)
+def _read_config_cached(config_file, mtime):
+    """Parse config.yaml, memoised by path and mtime. Do not mutate the result."""
+
+    with open(config_file) as f:
+        return yaml.safe_load(f)
+
+
+def _read_config(config_file):
+    """Return the parsed config.yaml, cached by path+mtime, as a fresh copy per call.
+
+    The mtime in the cache key means an edited config is re-read rather than served
+    stale. A copy per call because the cached instance is shared across the whole
+    session and callers (and tests) may adjust the config in place.
+    """
+
+    return deepcopy(_read_config_cached(str(config_file), config_file.stat().st_mtime))
 
 
 class Paths():
@@ -44,25 +94,13 @@ class Paths():
         # Do this by finding the location of the .git folder in the working directory
         # and then going up one level
         if not this_repo:
-            working_directory = _Path.cwd()
-            while True:
-                if (working_directory / ".git").exists():
-                    break
-                else:
-                    working_directory = working_directory.parent
-                    if working_directory == _Path("/"):
-                        raise FileNotFoundError("Can't find repository root")
+            working_directory = _find_working_directory(_Path.cwd())
         else:
             working_directory = _Path(__file__).parent.parent
 
-        # Within working directory find package folder 
+        # Within working directory find package folder
         # by looking for folder name with "_archive" in it, and __init__.py
-        for pth in working_directory.glob("*_archive"):
-            if (pth / "__init__.py").exists():
-                self.root = pth
-                break
-        else:
-            raise FileNotFoundError("Can't find package folder. Make sure your package has '_archive' in the folder name and __init__.py")
+        self.root = _find_package_root(working_directory)
 
         self.data = self.root.parent / "data"
 
@@ -78,10 +116,9 @@ class Paths():
             raise FileNotFoundError(
                 "Config file not found. Try running config.setup first")
 
-        # Read config file
-        with open(self.config_file) as f:
-            config = yaml.safe_load(f)
-        
+        # Read config file (cached by path+mtime)
+        config = _read_config(self.config_file)
+
         self.user = config["user"]["name"]
 
         # If network is not set, exit
@@ -416,6 +453,40 @@ def open_data_file(filename,
         return tarfile.open(pth / filename, f"{mode}:gz")
     else:
         return (pth / filename).open(f"{mode}b")
+
+
+@lru_cache(maxsize=None)
+def _load_json_cached(path, mtime):
+    """Parse a JSON file, memoised by absolute path and mtime. Do not mutate the result."""
+
+    with open(path, "rb") as f:
+        return json.load(f)
+
+
+def load_json(filename, network="", sub_path="", this_repo=False):
+    """Load and parse a JSON data file, caching the parse.
+
+    The schema and lookup JSON files (variables.json, attributes.json, standard_names.json,
+    variables_not_public.json, ale_gage_sites.json, ...) are read hundreds of times per
+    archive run but change only between runs. The parse is memoised by resolved path and
+    mtime; each call returns a fresh deep copy, so callers keep the mutable-dict semantics
+    of ``json.load`` — several overlay onto the result in place (``format_attributes``
+    merges network/site attributes onto attributes.json; ``read_data_exclude`` does
+    ``variable_defaults.update(...)`` on variables.json).
+
+    Args:
+        filename (str): JSON filename.
+        network (str, optional): Network. Defaults to "".
+        sub_path (str, optional): Sub-path. Defaults to "".
+        this_repo (bool, optional): Resolve within this repository. Defaults to False.
+
+    Returns:
+        The parsed JSON, as a fresh copy on every call.
+    """
+
+    pth = data_file_path(filename, network=network, sub_path=sub_path,
+                         this_repo=this_repo, errors="raise")
+    return deepcopy(_load_json_cached(str(pth), pth.stat().st_mtime))
 
 
 def output_path(network,

--- a/agage_archive/convert.py
+++ b/agage_archive/convert.py
@@ -4,7 +4,7 @@ import xarray as xr
 import json
 from openghg_calscales import convert as convert_scale
 
-from agage_archive.config import open_data_file
+from agage_archive.config import open_data_file, load_json
 from agage_archive.data_selection import calibration_scale_default
 from agage_archive.formatting import format_species, format_variables, comment_append
 
@@ -403,12 +403,10 @@ def resample(ds,
     """
 
     # Read variables.json
-    with open_data_file("variables.json", this_repo=True) as f:
-        variable_defaults = json.load(f)
+    variable_defaults = load_json("variables.json", this_repo=True)
 
     # Read variable defaults for non-public data to find how to resample these variables
-    with open_data_file("variables_not_public.json", this_repo=True) as f:
-        variable_np_defaults = json.load(f)
+    variable_np_defaults = load_json("variables_not_public.json", this_repo=True)
     variable_defaults.update(variable_np_defaults)
     
     # check if median time difference is less than minimum_averaging_period

--- a/agage_archive/data_selection.py
+++ b/agage_archive/data_selection.py
@@ -2,7 +2,7 @@ import pandas as pd
 import numpy as np
 import json
 
-from agage_archive.config import open_data_file, data_file_list
+from agage_archive.config import open_data_file, data_file_list, load_json
 from agage_archive.formatting import format_species
 
 
@@ -282,12 +282,10 @@ def read_data_exclude(ds, species, site, instrument,
         data_exclude = pd.read_csv(f, comment="#")
 
     # Read variable defaults to find what to do with missing data
-    with open_data_file("variables.json", this_repo=True) as f:
-        variable_defaults = json.load(f)
+    variable_defaults = load_json("variables.json", this_repo=True)
 
     # Read variable defaults for non-public data to find what to do with missing data
-    with open_data_file("variables_not_public.json", this_repo=True) as f:
-        variable_np_defaults = json.load(f)
+    variable_np_defaults = load_json("variables_not_public.json", this_repo=True)
     variable_defaults.update(variable_np_defaults)
 
     # Remove whitespace from strings

--- a/agage_archive/definitions.py
+++ b/agage_archive/definitions.py
@@ -1,4 +1,5 @@
 import numpy as np
+from functools import lru_cache
 
 from agage_archive.config import data_file_list
 
@@ -76,6 +77,32 @@ minimum_averaging_period = {"Picarro": "1H"}
 instrument_selection_text = "Recommended instrument(s) selected and combined by station PIs"
 
 
+@lru_cache(maxsize=None)
+def _define_instrument_number_cached(network):
+    '''Build the instrument-number map for a network (memoised).
+
+    The release-schedule directory is static within a run, but this is called per dataset
+    and per variable (via instrument_type_definition), so listing and sorting it every
+    time is pure overhead. Keyed on network; do not mutate the result.
+    '''
+
+    instrument_number = {"UNDEFINED": -1,}
+
+    _, _, files = data_file_list(network,
+                            sub_path = "data_release_schedule",
+                            pattern = "data_release_schedule_*.csv",)
+
+    if not files:
+        raise FileNotFoundError("No data release schedule files found for the specified network.")
+
+    counter = 0
+    for f in sorted(files):
+        instrument_number[f.split("_")[-1].split(".")[0]] = counter
+        counter += 1
+
+    return instrument_number
+
+
 def define_instrument_number(network):
     '''Define instrument numbers for each instrument type based on data release schedule files
 
@@ -86,21 +113,9 @@ def define_instrument_number(network):
         dict: Dictionary of instrument numbers
     '''
 
-    instrument_number = {"UNDEFINED": -1,}
-
-    _, _, files = data_file_list(network,
-                            sub_path = "data_release_schedule",
-                            pattern = "data_release_schedule_*.csv",)
-    
-    if not files:
-        raise FileNotFoundError("No data release schedule files found for the specified network.")
-    
-    counter = 0
-    for f in sorted(files):
-        instrument_number[f.split("_")[-1].split(".")[0]] = counter
-        counter += 1
-
-    return instrument_number
+    # Fresh copy per call: the cached map is shared, and callers should be free to treat
+    # the returned dict as their own.
+    return dict(_define_instrument_number_cached(network))
 
 
 def instrument_type_definition(network):

--- a/agage_archive/formatting.py
+++ b/agage_archive/formatting.py
@@ -5,7 +5,7 @@ from datetime import datetime
 import warnings
 
 from agage_archive import __version__ as code_version
-from agage_archive.config import open_data_file, data_file_path
+from agage_archive.config import open_data_file, data_file_path, load_json
 from agage_archive.util import is_number, lookup_username
 from agage_archive.definitions import instrument_type_definition, nc4_types
 
@@ -205,11 +205,9 @@ def format_variables(ds,
 
     network = ds.attrs["network"]
 
-    with open_data_file("variables.json", this_repo=True) as f:
-        variables = json.load(f)
-    
-    with open_data_file("standard_names.json", this_repo=True) as f:
-        standard_names=json.load(f)
+    variables = load_json("variables.json", this_repo=True)
+
+    standard_names = load_json("standard_names.json", this_repo=True)
 
     # Some attributes that we want to keep without changing
     attrs = ds.attrs.copy()
@@ -349,8 +347,7 @@ def format_attributes(ds, instruments = [],
         xr.Dataset: Dataset with formatted attributes
     '''
 
-    with open_data_file("attributes.json", this_repo=True) as f:
-        attributes_default = json.load(f)
+    attributes_default = load_json("attributes.json", this_repo=True)
 
     if network is None:
         if "network" in ds.attrs:
@@ -361,8 +358,7 @@ def format_attributes(ds, instruments = [],
         ds.attrs["network"] = network
         network_attrs = network
 
-    with open_data_file("attributes.json", network=network_attrs) as f:
-        attributes_network = json.load(f)
+    attributes_network = load_json("attributes.json", network=network_attrs)
 
     # Combine default and network attributes
     # Allow default attributes to be overwritten by network attributes

--- a/agage_archive/io.py
+++ b/agage_archive/io.py
@@ -543,8 +543,7 @@ def read_ale_gage(network, species, site, instrument,
     paths = Paths(network)
 
     # Get data on ALE/GAGE sites
-    with open_data_file("ale_gage_sites.json", network = network, verbose=verbose) as f:
-        site_info = json.load(f)
+    site_info = load_json("ale_gage_sites.json", network=network)
 
     # Get species info
     with open_data_file("ale_gage_species.json", network = network, verbose=verbose) as f:
@@ -844,8 +843,7 @@ def read_gcms_magnum(network, species,
     """
 
     # Get data on ALE/GAGE sites
-    with open_data_file("ale_gage_sites.json", network = network, verbose=verbose) as f:
-        site_info = json.load(f)
+    site_info = load_json("ale_gage_sites.json", network=network)
 
     # Get species info
     with open_data_file("gcms-magnum_species.json", network = network, verbose=verbose) as f:

--- a/agage_archive/io.py
+++ b/agage_archive/io.py
@@ -6,7 +6,7 @@ from zipfile import ZipFile, ZIP_DEFLATED
 import json
 
 from agage_archive.config import Paths, open_data_file, data_file_list, \
-    output_path
+    output_path, load_json
 from agage_archive.convert import scale_convert
 from agage_archive.convert import resample as resample_function
 from agage_archive.formatting import format_species, \
@@ -352,8 +352,7 @@ def read_baseline(network, species, site, instrument,
         xarray.Dataset: Contents of netCDF file
     """
 
-    with open_data_file("attributes.json", network=network) as f:
-        attributes_default = json.load(f)
+    attributes_default = load_json("attributes.json", network=network)
 
     read_function = get_data_read_function(network, instrument)
 

--- a/agage_archive/util.py
+++ b/agage_archive/util.py
@@ -12,7 +12,7 @@ import unicodedata
 
 from agage_archive.config import Paths, open_data_file, data_file_path, \
     data_file_list, delete_archive, create_empty_archive, \
-    output_path
+    output_path, load_json
 
 
 def is_number(s):
@@ -71,8 +71,7 @@ def tz_local_to_utc(index, network, site):
         pandas.DatetimeIndex: Datetime index in UTC
     """
 
-    with open_data_file("ale_gage_sites.json", network=network) as file:
-        site_info = json.load(file)
+    site_info = load_json("ale_gage_sites.json", network=network)
 
     tzoffset_hours = site_info[site]["tz"].split("UTC")[1]
 

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -119,20 +119,21 @@ def archive_manifest(root):
 def _patch_config_output(monkeypatch, output_path_value):
     """Redirect the agage_test output_path for the duration of a run.
 
-    Paths re-reads config.yaml (via yaml.safe_load) on every construction, so patching
-    the loader is the least invasive way to point the output somewhere else without
-    editing the user's config file. The guard leaves any non-config YAML untouched, so
-    only the network's output_path is affected.
+    Patches config.py's cached config reader rather than the user's config.yaml. Going
+    through _read_config (not yaml.safe_load) is deliberate: the config parse is memoised,
+    so patching the loader below the cache would be served a stale, unpatched result.
+    _read_config already hands back a fresh copy, so adjusting it here cannot poison the
+    cache, and the guard leaves any non-agage_test config untouched.
 
     Args:
         monkeypatch (pytest.MonkeyPatch): Patcher to register the override on.
         output_path_value (str): Value to substitute for the network's output_path.
     """
 
-    real_safe_load = agage_archive.config.yaml.safe_load
+    real_read_config = agage_archive.config._read_config
 
-    def patched(stream):
-        loaded = real_safe_load(stream)
+    def patched(config_file):
+        loaded = real_read_config(config_file)
         try:
             network_paths = loaded["paths"][NETWORK]
         except (TypeError, KeyError):
@@ -140,7 +141,7 @@ def _patch_config_output(monkeypatch, output_path_value):
         loaded["paths"][NETWORK] = {**network_paths, "output_path": output_path_value}
         return loaded
 
-    monkeypatch.setattr(agage_archive.config.yaml, "safe_load", patched)
+    monkeypatch.setattr(agage_archive.config, "_read_config", patched)
 
 
 @pytest.fixture(scope="module", params=["directory", "zip"])

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -2,10 +2,11 @@ import pandas as pd
 import xarray as xr
 import numpy as np
 import json
+from copy import deepcopy
 from io import BytesIO
 from unittest.mock import patch
 
-from agage_archive.config import Paths, open_data_file
+from agage_archive.config import Paths, open_data_file, load_json
 from agage_archive.io import read_ale_gage, read_nc, combine_datasets, read_nc_path, \
     read_baseline, combine_baseline, output_dataset, read_gcwerks_flask, drop_duplicates, \
     read_gcms_magnum_file, read_gcms_magnum, define_instrument_type, get_data_read_function, \
@@ -73,8 +74,7 @@ def test_read_ale_gage_site_code_uppercased():
     differently-cased site argument would silently produce a differently-cased
     site_code, which feeds directly into the output filename."""
 
-    with open_data_file("ale_gage_sites.json", network="agage_test") as f:
-        site_info = json.load(f)
+    site_info = load_json("ale_gage_sites.json", network="agage_test")
     site_info["cgo"] = site_info["CGO"]
 
     with open_data_file("ale_gage_timestamp_issues.json", network="agage_test") as f:
@@ -82,19 +82,25 @@ def test_read_ale_gage_site_code_uppercased():
     timestamp_issues["ALE"]["cgo"] = timestamp_issues["ALE"]["CGO"]
 
     real_open_data_file = open_data_file
+    real_load_json = load_json
+
+    def fake_load_json(filename, *args, **kwargs):
+        if filename == "ale_gage_sites.json":
+            return deepcopy(site_info)
+        return real_load_json(filename, *args, **kwargs)
 
     def fake_open_data_file(filename, *args, **kwargs):
-        if filename == "ale_gage_sites.json":
-            return BytesIO(json.dumps(site_info).encode())
         if filename == "ale_gage_timestamp_issues.json":
             return BytesIO(json.dumps(timestamp_issues).encode())
         return real_open_data_file(filename, *args, **kwargs)
 
     # read_release_schedule does its own case-sensitive site lookup, which is
     # out of scope here (tracked separately); skip it to isolate the site_code fix.
-    # tz_local_to_utc (in util.py) does its own ale_gage_sites.json lookup too.
-    with patch("agage_archive.io.open_data_file", side_effect=fake_open_data_file), \
-         patch("agage_archive.util.open_data_file", side_effect=fake_open_data_file), \
+    # ale_gage_sites.json is now loaded via the cached load_json, so it is injected there;
+    # tz_local_to_utc (in util.py) does its own load_json lookup too.
+    with patch("agage_archive.io.load_json", side_effect=fake_load_json), \
+         patch("agage_archive.util.load_json", side_effect=fake_load_json), \
+         patch("agage_archive.io.open_data_file", side_effect=fake_open_data_file), \
          patch("agage_archive.io.read_release_schedule", return_value=None):
         ds = read_ale_gage("agage_test", "ch3ccl3", "cgo", "ALE",
                            data_exclude=False, dropna=False)
@@ -617,20 +623,20 @@ def test_read_gcms_magnum_site_code_uppercased():
     argument (looked up here under a lowercase alias in ale_gage_sites.json)
     must still produce the canonical upper-case site_code."""
 
-    with open_data_file("ale_gage_sites.json", network="agage_test") as f:
-        site_info = json.load(f)
+    site_info = load_json("ale_gage_sites.json", network="agage_test")
     site_info["mhd"] = site_info["MHD"]
 
-    real_open_data_file = open_data_file
+    real_load_json = load_json
 
-    def fake_open_data_file(filename, *args, **kwargs):
+    def fake_load_json(filename, *args, **kwargs):
         if filename == "ale_gage_sites.json":
-            return BytesIO(json.dumps(site_info).encode())
-        return real_open_data_file(filename, *args, **kwargs)
+            return deepcopy(site_info)
+        return real_load_json(filename, *args, **kwargs)
 
     # read_release_schedule does its own case-sensitive site lookup, which is
     # out of scope here (tracked separately); skip it to isolate the site_code fix.
-    with patch("agage_archive.io.open_data_file", side_effect=fake_open_data_file), \
+    # ale_gage_sites.json is now loaded via the cached load_json, so it is injected there.
+    with patch("agage_archive.io.load_json", side_effect=fake_load_json), \
          patch("agage_archive.io.read_release_schedule", return_value=None):
         ds = read_gcms_magnum("agage_test", "hfc-134a", site="mhd",
                              data_exclude=False, dropna=True)


### PR DESCRIPTION
Implements **P1, P2 and P3** from STATUS.md Phase 2 — three caches of file reads that repeat hundreds of times per archive run. Bundled per the plan, as separate commits.

## The changes

| | Cache | Per cold `combine_datasets` call |
| --- | --- | --- |
| **P1** | `.git` walk, `*_archive` glob, `config.yaml` parse, and a new memoised `load_json` for the schema files | config parses **322 → 1**, package glob **357 → 1**, JSON parses **283 → 6** |
| **P2** | `define_instrument_number` (release-schedule directory listing) | listings **22 → 1** |
| **P3** | `ale_gage_sites.json` via `load_json` (read once per monthly ALE/GAGE file) | folded into the JSON count above |

## Correctness: copy-on-return, not a shared instance

The one real hazard with caching these is mutation. Several callers overlay onto what they load **in place** — `format_attributes` merges network/site attributes onto `attributes.json`, and `read_data_exclude` does `variable_defaults.update(...)` on `variables.json`. A shared cached dict would be poisoned by the first call and, because the cache lives for the whole session, would surface as an order-dependent failure. So `load_json` memoises the *parse* and returns a fresh `deepcopy` per call; `define_instrument_number` returns a fresh `dict`. Consumers keep the exact mutable-dict semantics of `json.load`.

## Verification

- **Golden manifest (directory + zip) byte-identical** under `PYTHONHASHSEED` **0** and **12345** — output unchanged and seed-independent. (An earlier apparent seed-12345 failure was a harness collision from running another suite against the shared `output/` dir concurrently; it passes in isolation.)
- `combine_datasets('agage_test','ch3ccl3','CGO')`: **2.26 s → 1.90 s (16% faster)** on repeated calls, same machine.
- Fast suite: **85 passed**.

## Test change

The two `site_code`-casing tests injected a lowercase-aliased `ale_gage_sites.json` by patching `open_data_file`; that read now goes through `load_json`, so they patch `load_json` and return the parsed dict. `test_archive`'s zip config override moves from patching `yaml.safe_load` to patching `_read_config`, since the parse is now memoised below that point.

## Not included

`io_other_formats.py` reads `ale_gage_sites.json` directly but is off the archive hot path (0% coverage), so it was left untouched to avoid changing uncovered code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X1HUQQdPf5u3ocNaX8vCe8