### PR TITLE
Cache the raw ALE/GAGE tar read across species and workflows (P6)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -5,7 +5,7 @@ Working plan for the code-quality pass on `agage-archive`. Read
 structure must not change.
 
 **Started:** 2026-07-28
-**Last updated:** 2026-07-31 (P4 drop_duplicates vectorised; T5 done)
+**Last updated:** 2026-07-31 (P6 raw ALE/GAGE read cached; P5 WONTFIX; P7 logged)
 
 Update the checkboxes and the "Last updated" date as items land. Keep the findings
 register at the bottom in sync — if an item turns out to be a non-issue, mark it
@@ -330,25 +330,36 @@ under `PYTHONHASHSEED` 0 and 12345. PR bundles the three as separate commits.
       new — including the all-NaN branch (was unexecuted, covers T5's duplicate case) and a
       check that extra data variables ride along. Micro-benchmark (6000 rows, 3000 dropped):
       **2185 ms → 5.6 ms (~390×)**; golden manifest (directory + zip) byte-identical.
-- [ ] **P5 — Stop calling `format_variables` two or three times per dataset.** It rebuilds
-      the whole Dataset and re-reads three JSON files each time (`read_nc`, then
-      `combine_datasets`).
-- [ ] **P6 — Cache the raw per-instrument read+resample shared by both workflows.** Every
-      source file is read and resampled once for the individual product
-      (`run_individual_site` → `read_function`) and again for the combined product
-      (`combine_datasets` → `_read_combined_instrument_datasets` → same `read_function`).
-      Cache the raw read+resample keyed on `(network, species, site, instrument)` and let
-      each workflow apply its own downstream transforms. **The two products legitimately
-      diverge *after* the raw read** — the individual file uses the instrument-specific
-      scale (`choose_scale_defaults_file(network, instrument, site)`) while the combined
-      file uses the `"combined"` scale, the combined path applies an extra
-      `read_data_exclude(..., combined=True)` layer, and it slices to the `data_combination`
-      date window — so the cache must sit before scale conversion, the combined exclusion,
-      and windowing, not after. This is a caching change, **not** a merge of the two
-      workflows (see decisions log 2026-07-30).
+- [x] **P5 — Stop calling `format_variables` two or three times per dataset.** ❌ WONTFIX
+      (2026-07-31) — subsumed by P1. It is still called 5× per `combine_datasets`, but now
+      costs **6 ms (0% of the call)**: P1's `load_json` cache removed the JSON re-reads that
+      were its whole rationale. Removing the calls would save ~5 ms while touching
+      output-defining code (Phase 4 S2 territory) — bad risk/reward. Profiling instead
+      pointed at the real costs: the fixed-width ALE/GAGE file reads (~53%, addressed by P6)
+      and the sympy calibration-scale conversion (~33%, logged as P7).
+- [x] **P6 — Cache the raw per-instrument read shared across species and workflows.** ✅ Done
+      2026-07-31. The originally-planned "split before `scale_convert`" boundary turned out
+      non-uniform (`read_gcwerks_flask` bakes scale in via `format_attributes`/
+      `format_variables`, not a trailing `scale_convert`), and profiling showed the dominant
+      redundant cost is the ALE/GAGE *file read*, not resample. `read_ale_gage` opens a tar
+      of monthly fixed-width files and builds a dataframe of **all species**; species
+      selection happens only afterwards. Extracted that species-independent core into
+      `_read_ale_gage_raw(network, site, instrument, utc)`, memoised (copy-on-return). It is
+      shared across every species *and* across the individual/combined workflows, which each
+      re-read the whole archive today. **Full `run_all` on `agage_test`: 65.0 s → 35.6 s
+      (45%)**; golden manifest (directory + zip) byte-identical.
+- [ ] **P7 — Cache the calibration-scale conversion (new, from P5 profiling).** ~33% of a
+      `combine_datasets` call is `openghg_calscales.convert` rebuilding the sympy scale
+      graph (`_scale_graph` → `nsimplify`/`pslq`) on every read. The derivation depends only
+      on `(species, scale_from, scale_to)`, not the data, so it is cacheable in principle —
+      but conversions can be **non-linear** (polynomial), so a scalar-factor cache is unsafe,
+      and doing it properly means caching the library's private `_scale_graph` or an upstream
+      contribution to `openghg_calscales`. Higher effort, dependency-bound; assess before
+      committing.
 
 **Target:** ≥40% reduction in wall time for a full `agage_test` run, byte-identical output
-modulo the three volatile attributes.
+modulo the three volatile attributes. **Met by P6 alone (45%);** P1–P3 (config/JSON) and
+P4 (drop_duplicates) compound on top.
 
 ---
 

--- a/agage_archive/io.py
+++ b/agage_archive/io.py
@@ -3,7 +3,7 @@ import json
 import pandas as pd
 import numpy as np
 from zipfile import ZipFile, ZIP_DEFLATED
-import json
+from functools import lru_cache
 
 from agage_archive.config import Paths, open_data_file, data_file_list, \
     output_path, load_json
@@ -494,6 +494,84 @@ def read_ale_gage_file(f, network, site,
     return df
 
 
+@lru_cache(maxsize=None)
+def _read_ale_gage_raw(network, site, instrument, utc):
+    """Read and concatenate all monthly ALE/GAGE files for a site into one dataframe.
+
+    This is the expensive, species-independent core of read_ale_gage: opening the tar
+    archive and parsing every monthly fixed-width file (hundreds of read_fwf calls). The
+    result keeps every species' columns; read_ale_gage picks out the one it needs. Since
+    it is identical across species and across the individual and combined workflows — each
+    of which would otherwise re-read the whole archive — it is memoised on
+    (network, site, instrument, utc). Callers must copy it before mutating.
+
+    Args:
+        network (str): Network.
+        site (str): Site code.
+        instrument (str): "ALE" or "GAGE".
+        utc (bool): Convert timestamps to UTC.
+
+    Returns:
+        pd.DataFrame: All monthly records concatenated, sorted, de-NaN-indexed and
+            duplicate-checked, with every species column retained.
+    """
+
+    paths = Paths(network)
+    site_info = load_json("ale_gage_sites.json", network=network)
+
+    # Get Datetime issues list
+    with open_data_file("ale_gage_timestamp_issues.json", network=network) as f:
+        timestamp_issues = json.load(f)
+        if site in timestamp_issues[instrument]:
+            timestamp_issues = timestamp_issues[instrument][site]
+        else:
+            timestamp_issues = {}
+
+    # Path to relevant sub-folder
+    folder = paths.__getattribute__(f"{instrument}_path")
+
+    with open_data_file(f"{site_info[site]['gcwerks_name']}_sio1993.gtar.gz",
+                        network=network,
+                        sub_path=folder) as tar:
+
+        dfs = []
+
+        for member in tar.getmembers():
+
+            # Extract tar file
+            f = tar.extractfile(member)
+
+            df = read_ale_gage_file(f, network, site,
+                                timestamp_issues=timestamp_issues,
+                                utc=utc,
+                                verbose=False)
+
+            # append data frame if it's not all NaN
+            if not df.empty:
+                dfs.append(df)
+
+    # Concatenate monthly dataframes into single dataframe
+    df_combined = pd.concat(dfs)
+
+    # Sort
+    df_combined.sort_index(inplace=True)
+
+    # Check if there are NaN indices
+    if len(df_combined.index[df_combined.index.isna()]) > 0:
+        raise ValueError("NaN indices found. Check timestamp issues.")
+
+    # Drop na indices
+    df_combined = df_combined.loc[~df_combined.index.isna(), :]
+
+    # Check if there are duplicate indices
+    if len(df_combined.index) != len(df_combined.index.drop_duplicates()):
+        # Find which indices are duplicated
+        duplicated_indices = df_combined.index[df_combined.index.duplicated(keep=False)]
+        raise ValueError(f"Duplicate indices found. Check timestamp issues: {duplicated_indices}")
+
+    return df_combined
+
+
 def read_ale_gage(network, species, site, instrument,
                   verbose = True,
                   utc = True,
@@ -528,8 +606,6 @@ def read_ale_gage(network, species, site, instrument,
     if instrument not in ["ALE", "GAGE"]:
         raise ValueError("instrument must be ALE or GAGE")
 
-    paths = Paths(network)
-
     # Get data on ALE/GAGE sites
     site_info = load_json("ale_gage_sites.json", network=network)
 
@@ -537,56 +613,10 @@ def read_ale_gage(network, species, site, instrument,
     with open_data_file("ale_gage_species.json", network = network, verbose=verbose) as f:
         species_info = json.load(f)[format_species(species)]
 
-    # Get Datetime issues list
-    with open_data_file("ale_gage_timestamp_issues.json", network = network, verbose=verbose) as f:
-        timestamp_issues = json.load(f)
-        if site in timestamp_issues[instrument]:
-            timestamp_issues = timestamp_issues[instrument][site]
-        else:
-            timestamp_issues = {}
-
-    # Path to relevant sub-folder
-    folder = paths.__getattribute__(f"{instrument}_path")
-
-    with open_data_file(f"{site_info[site]['gcwerks_name']}_sio1993.gtar.gz",
-                        network = network,
-                        sub_path = folder,
-                        verbose=verbose) as tar:
-
-        dfs = []
-
-        for member in tar.getmembers():
-
-            # Extract tar file
-            f = tar.extractfile(member)
-            
-            df = read_ale_gage_file(f, network, site,
-                                timestamp_issues=timestamp_issues,
-                                utc=utc,
-                                verbose=verbose)
-
-            # append data frame if it's not all NaN
-            if not df.empty:
-                dfs.append(df)
-
-    # Concatenate monthly dataframes into single dataframe
-    df_combined = pd.concat(dfs)
-
-    # Sort
-    df_combined.sort_index(inplace=True)
-
-    # Check if there are NaN indices
-    if len(df_combined.index[df_combined.index.isna()]) > 0:
-        raise ValueError("NaN indices found. Check timestamp issues.")
-
-    # Drop na indices
-    df_combined = df_combined.loc[~df_combined.index.isna(),:]
-
-    # Check if there are duplicate indices
-    if len(df_combined.index) != len(df_combined.index.drop_duplicates()):
-        # Find which indices are duplicated
-        duplicated_indices = df_combined.index[df_combined.index.duplicated(keep=False)]
-        raise ValueError(f"Duplicate indices found. Check timestamp issues: {duplicated_indices}")
+    # Read and concatenate every monthly file (all species). This is the expensive part
+    # and is species-independent, so it is cached and shared across species and across the
+    # individual/combined workflows. Copy so downstream edits never touch the cached frame.
+    df_combined = _read_ale_gage_raw(network, site, instrument, utc).copy()
 
     # Store pollution flag
     da_baseline = (df_combined[f"{species_info['species_name_gatech']}_pollution"] != "P").astype(np.int8)


### PR DESCRIPTION
Implements **P6** from Phase 2. Also records **P5 as WONTFIX** (subsumed by P1) and logs a new **P7** candidate — see the "How this differs from the plan" section.

## The redundancy

`read_ale_gage` opens a tar of monthly fixed-width files and concatenates them into one dataframe holding **every species' columns**, then selects the one species it needs. That tar read — hundreds of `read_fwf` calls, ~53% of a `combine_datasets` call — is **species-independent**, yet today it is repeated:

- once per species (ch3ccl3, ccl4, cfc-11, cfc-12, n2o … all re-read the same CGO archive), and
- again in the individual-instrument workflow.

## The change

Extract the species-independent core into `_read_ale_gage_raw(network, site, instrument, utc)`, memoised with **copy-on-return** (downstream code mutates the frame, so a shared instance would be poisoned). The archive is now parsed once per site/instrument and shared across every species and both workflows.

## Results

- **Full `run_all` on `agage_test`: 65.0 s → 35.6 s (45%)** — clears the Phase 2 ≥40% target on its own.
- One `combine_datasets` call: repeated calls **1.9 s → 0.76 s** (the first, cold call is unchanged — the win is the sharing).
- **Golden manifest (directory + zip) byte-identical.** Fast suite **89 passed**.

## How this differs from the plan

The STATUS note for P6 proposed splitting each reader before `scale_convert`. Two findings changed that:

1. **Not uniform.** `read_nc`/`read_ale_gage`/`read_gcms_magnum` end with `scale_convert(ds, scale)`, but `read_gcwerks_flask` has none — it bakes the scale in earlier via `format_attributes`/`format_variables`. A uniform split would have been risky for flask.
2. **The cost is the file read, not resample.** Profiling put the redundant cost in `read_fwf`; resample barely registered. Caching the tar read is uniform, sidesteps the flask asymmetry, is memory-light (species-independent → a handful of entries), and captures the dominant share.

Two items also settled from the P5 investigation (details in STATUS):
- **P5 → WONTFIX:** `format_variables` now costs 6 ms (0%); P1 already removed its JSON re-reads.
- **P7 (new):** the sympy calibration-scale conversion is ~33% of a `combine_datasets` call, cacheable in principle but non-linear and living in `openghg_calscales` — logged as a separate, higher-effort candidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X1HUQQdPf5u3ocNaX8vCe8