### PR TITLE
Fix archive_to_csv crash on directory archives; add end-to-end test (T6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Scale-default file selection now breaks equal-specificity ties by filename rather than filesystem order.
 - `open_data_file` now keeps a ZIP archive open for the lifetime of the member handle it returns and closes it when that handle is closed, instead of closing the archive first and relying on CPython's `ZipExtFile` reference counting to keep the closed archive readable.
 - `read_ale_gage`, `read_gcms_magnum` and `read_gcwerks_flask` now upper-case `site_code` in output attributes, matching `read_nc` and `read_baseline`. Previously they stored the raw `site` argument, so a differently-cased site code would silently fail the case-sensitive `attributes_site.json` lookup in `format_attributes`, dropping station metadata with no error.
+- `archive_to_csv` no longer crashes on a directory-based archive. `data_file_list` yields subdirectory entries (with a trailing slash) for a directory archive; these were treated as non-netCDF files and passed to `read_text`, raising `FileNotFoundError`. They are now skipped. Zip archives were unaffected, as they contain no such entries.
 
 ### Changed
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -5,7 +5,7 @@ Working plan for the code-quality pass on `agage-archive`. Read
 structure must not change.
 
 **Started:** 2026-07-28
-**Last updated:** 2026-07-31 (P6 raw ALE/GAGE read cached; P5 WONTFIX; P7 logged)
+**Last updated:** 2026-07-31 (T6 archive_to_csv covered; fixed directory-entry crash)
 
 Update the checkboxes and the "Last updated" date as items land. Keep the findings
 register at the bottom in sync — if an item turns out to be a non-issue, mark it
@@ -393,8 +393,14 @@ P4 (drop_duplicates) compound on top.
       duplicate-timestamp cases for `drop_duplicates` landed with P4 (non-NaN preference,
       instrument priority, the all-NaN branch, and multi-timestamp/extra-variable
       preservation).
-- [ ] **T6 — `util.archive_to_csv` end-to-end.** 0% covered and it produces a published
-      archive.
+- [x] **T6 — `util.archive_to_csv` end-to-end.** ✅ Done 2026-07-31. `tests/test_util.py`
+      builds a small real archive (one GCMS-Medusa species/site, no combined/baseline, so
+      no slow ALE/GAGE reads), runs `archive_to_csv`, and checks each `.nc` gains a `.csv`
+      counterpart and non-nc files are copied verbatim. Writing it exposed a crash: on a
+      directory archive `data_file_list` yields trailing-slash subdirectory entries, which
+      `archive_to_csv` fed to `read_text` — fixed by skipping them (see CHANGELOG). Zip
+      archives (the usual release format) had no such entries, which is why 0% coverage let
+      it hide.
 - [ ] **T7 — Input configuration consistency checks** (#97). Validate that species names
       agree across release schedules, scale-default files and `standard_names.json`; check
       that configured dates parse successfully and that end dates are not before start

--- a/agage_archive/util.py
+++ b/agage_archive/util.py
@@ -411,6 +411,10 @@ def archive_to_csv(network):
     print(f"Converting {len(files)} files to CSV format...")
 
     for f in tqdm(files):
+        # data_file_list yields subdirectory entries (with a trailing slash) for a
+        # directory-based archive; there is nothing to convert or copy for those.
+        if f.endswith("/"):
+            continue
         if not f.endswith(".nc"):
             # Copy the file as is
             archive_write_csv(csv_archive_path, f,

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -4,9 +4,13 @@ from pathlib import Path
 from zipfile import ZipFile
 import tempfile
 import os
+import shutil
 from pathlib import Path
 
-from agage_archive.util import parse_fortran_format, nc_to_csv, archive_write_csv
+from agage_archive.config import data_file_path
+from agage_archive.run import run_all
+from agage_archive.util import parse_fortran_format, nc_to_csv, archive_write_csv, \
+    archive_to_csv
 
 
 def test_parse_fortran_format():
@@ -144,3 +148,50 @@ def test_archive_write_csv():
         with open(non_zip_path / filename_with_subpath, mode="r", encoding="utf-8-sig") as f:
             content = f.read()
             assert content == data, f"Content of {non_zip_path / filename_with_subpath} does not match expected data"
+
+
+def test_archive_to_csv_end_to_end(clean_output):
+    """archive_to_csv converts a populated nc archive into a parallel csv archive.
+
+    Exercises the whole orchestration end to end: every .nc file is converted to .csv
+    (via nc_to_csv/archive_write_csv) at the same relative path, and non-nc files
+    (README/CHANGELOG) are copied verbatim. Uses a deliberately small archive — one
+    GCMS-Medusa species at one site, no combined products or baselines — so it avoids the
+    slow ALE/GAGE reads and stays fast.
+    """
+
+    nc_root = clean_output
+    csv_root = nc_root.parent / "output-csv"
+
+    run_all("agage_test", delete=True, combined=False, baseline=False, monthly=False,
+            instrument_include=["GCMS-Medusa"], species=["nf3"], sites=["MHD"])
+
+    try:
+        archive_to_csv("agage_test")
+
+        nc_files = sorted(p.relative_to(nc_root).as_posix() for p in nc_root.rglob("*.nc"))
+        assert nc_files, "no nc files were produced to convert"
+
+        # Every .nc file has a .csv counterpart at the same relative path
+        for rel in nc_files:
+            csv_rel = rel[:-len(".nc")] + ".csv"
+            assert (csv_root / csv_rel).exists(), f"missing csv for {rel}"
+
+        # Non-nc archive files (README/CHANGELOG) are copied verbatim
+        for name in ("README.md", "CHANGELOG.md"):
+            if (nc_root / name).exists():
+                assert (csv_root / name).read_text(encoding="utf-8-sig") == \
+                    data_file_path(name, "agage_test").read_text(encoding="utf-8"), \
+                    f"{name} not copied verbatim to the csv archive"
+
+        # Spot-check one converted file: header markers plus data with split time columns
+        sample = sorted(csv_root.rglob("*.csv"))[0]
+        text = sample.read_text(encoding="utf-8-sig")
+        assert "converted from netCDF to CSV" in text
+        assert "# GLOBAL ATTRIBUTES:" in text
+        _, _, data = text.partition("# DATA:\n")
+        data_columns = data.splitlines()[0].split(",")
+        for col in ("year", "month", "day", "hour", "minute", "second", "mf"):
+            assert col in data_columns, f"{col} column missing from csv data"
+    finally:
+        shutil.rmtree(csv_root, ignore_errors=True)


### PR DESCRIPTION
Implements **T6** (end-to-end coverage for `util.archive_to_csv`) and fixes a crash the test exposed.

## The test (T6)

`archive_to_csv` had **0% coverage**. The new `test_archive_to_csv_end_to_end` builds a small real archive (one GCMS-Medusa species at one site, no combined products or baselines — so it skips the slow ALE/GAGE reads and runs in <1 s), converts it, and asserts:
- every `.nc` file gains a `.csv` counterpart at the same relative path,
- `README.md`/`CHANGELOG.md` are copied verbatim,
- a converted file has the expected header markers and split time columns.

## The bug it exposed

`archive_to_csv` **crashed on any directory-based archive**. `data_file_list` yields subdirectory entries with a trailing slash (`'nf3/'`, `'nf3/individual-instruments/'`) for a directory archive. These don't end in `.nc`, so they fell into the "copy non-nc file verbatim" branch, which called `read_text()` on a directory → `FileNotFoundError` (`util.py:417`).

**Why it hid:** real release archives are written as zip, and the zip writer (`writestr`) never creates bare directory entries, so production `output.zip` files have no trailing-slash members and the function works. Only directory output — which the `agage_test` config uses — hits it, and nothing had ever run `archive_to_csv` against a directory archive.

## The fix

Skip trailing-slash directory entries in the conversion loop. One `continue`. No change to the zip path or to any successfully-produced output; it only stops the crash on directory archives.

## Verification

- New end-to-end test passes; full fast suite **90 passed**.
- CHANGELOG entry added under Fixed; STATUS marks T6 done.

Not touched here (noted for later): the non-nc branch reads `data_file_path(f, network)` from the source root rather than the output archive — it works only because README/CHANGELOG exist identically in both. Separate, latent, not the cause of the crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X1HUQQdPf5u3ocNaX8vCe8