### PR TITLE
Nest zip archives under a single top-level version folder

### DIFF
--- a/agage_archive/config.py
+++ b/agage_archive/config.py
@@ -649,6 +649,68 @@ def archive_suffix(path, suffix):
         return name
 
 
+def archive_zip_root(archive_path, version=""):
+    """Top-level folder that a zip archive's members nest under.
+
+    So the zip extracts into a single self-named directory
+    (e.g. ``agage-public-archive-testv1/``) rather than scattering its
+    contents into the extraction directory. Applies to zip archives only;
+    directory-based outputs are already a named container.
+
+    Args:
+        archive_path (Path or str): Path to the .zip archive.
+        version (str, optional): Version string from the network's
+            attributes.json. Appended to the folder name when present.
+    Returns:
+        str: Folder name to prepend to each member path.
+    """
+
+    stem = _Path(archive_path).name.split(".zip")[0]
+    version = version.replace(" ", "") if version else ""
+    return f"{stem}-{version}" if version else stem
+
+
+def nest_archive_zip(network, archive_suffix_string=""):
+    """Repackage the output zip so every member sits under one top-level folder.
+
+    The whole processing pipeline writes members at archive-relative paths (e.g.
+    ``ch4/file.nc``) because it reads them back by that path while combining. This is
+    the final packaging step: it rewrites the finished zip so its members nest under a
+    single ``<stem>-<version>`` folder, so the archive extracts into one self-named
+    directory rather than scattering its contents. Directory-based outputs already are a
+    named container and are left untouched.
+
+    Idempotent: if the archive is already nested under the expected root it is left as is.
+
+    Args:
+        network (str): Network for output filenames.
+        archive_suffix_string (str, optional): Suffix on the archive name (e.g. "-csv").
+            Defaults to "".
+    """
+
+    archive_path, _ = output_path(network, "_", "_", "_",
+                                  errors="ignore_inputs",
+                                  extra_archive=archive_suffix_string)
+
+    if archive_path.suffix != ".zip" or not archive_path.exists():
+        return
+
+    version = load_json("attributes.json", network=network).get("version", "")
+    root = archive_zip_root(archive_path, version)
+
+    tmp_path = archive_path.with_name(archive_path.name + ".tmp")
+    with ZipFile(archive_path, "r") as src:
+        members = src.infolist()
+        if members and all(m.filename.split("/", 1)[0] == root for m in members):
+            # Already nested (e.g. a re-run over an existing archive)
+            return
+        # Stream member by member so a large archive is never held wholly in memory
+        with ZipFile(tmp_path, "w", compression=ZIP_DEFLATED, compresslevel=6) as dst:
+            for m in members:
+                dst.writestr(f"{root}/{m.filename}", src.read(m))
+    tmp_path.replace(archive_path)
+
+
 def delete_archive(network, archive_suffix_string=""):
     """Delete all files in output directory before running
 

--- a/agage_archive/run.py
+++ b/agage_archive/run.py
@@ -5,7 +5,7 @@ import traceback
 from tqdm import tqdm
 
 from agage_archive.config import Paths, open_data_file, data_file_list, data_file_path, \
-    copy_to_archive, delete_archive, create_empty_archive
+    copy_to_archive, delete_archive, create_empty_archive, nest_archive_zip
 from agage_archive.data_selection import read_release_schedule, read_data_combination, \
     choose_scale_defaults_file, data_combination_species
 from agage_archive.io import combine_datasets, combine_baseline, \
@@ -662,6 +662,11 @@ def run_all(network,
         copy_to_archive(changelog_file, network)
     except FileNotFoundError:
         logger.info("No CHANGELOG file found")
+
+    # Final packaging: nest a zip archive under a single top-level folder so it extracts
+    # into one self-named directory. Done last, after all read-back-during-combine is
+    # complete, so processing still sees archive-relative member paths.
+    nest_archive_zip(network)
 
     # If error log files have been created, warn the user
     if data_file_path("error_log_combined.txt", network=network, errors="ignore").exists():

--- a/agage_archive/util.py
+++ b/agage_archive/util.py
@@ -13,7 +13,7 @@ import unicodedata
 
 from agage_archive.config import Paths, open_data_file, data_file_path, \
     data_file_list, delete_archive, create_empty_archive, \
-    output_path, load_json
+    output_path, load_json, archive_zip_root
 
 logger = logging.getLogger(__name__)
 
@@ -351,12 +351,14 @@ def nc_to_csv(ds):
     return header, df
 
 
-def archive_write_csv(archive_path, filename, data):
+def archive_write_csv(archive_path, filename, data, version=""):
     """Write data to a CSV file in an archive or directory.
     Args:
         archive_path (Path): Path to the archive or directory
         filename (str): Name of the file to write
         data (str): Data to write to the file
+        version (str, optional): Network version (from attributes.json), used to
+            name the top-level folder inside a zip archive. Defaults to "".
     Returns:
         None: Writes the data to the specified file in the archive or directory
     """
@@ -371,8 +373,9 @@ def archive_write_csv(archive_path, filename, data):
 
     if archive_path.suffix == ".zip":
         with ZipFile(archive_path, mode="a", compression=ZIP_DEFLATED, compresslevel=6) as zip:
-            # prepend the archive name to the output filename so that it unzips to a folder
-            output_filename = archive_path.name.split(".zip")[0] + "/" + filename
+            # Nest members under a single top-level folder (mirroring the .nc archive)
+            # so the zip extracts into one self-named directory rather than scattering files.
+            output_filename = f"{archive_zip_root(archive_path, version)}/{filename}"
             # Explicitly encode as UTF-8 to prevent character encoding issues
             # Use 'utf-8-sig' to add BOM for better compatibility with some programs
             zip.writestr(output_filename, data.encode('utf-8-sig'))
@@ -398,6 +401,10 @@ def archive_to_csv(network):
 
     paths = Paths(network, errors="ignore_inputs")
 
+    # Network version (from attributes.json) names the top-level folder inside the
+    # csv zip, mirroring the .nc archive.
+    version = load_json("attributes.json", network=network).get("version", "")
+
     # Delete the csv archive if it exists and create an empty one
     delete_archive(network,
                    archive_suffix_string = archive_suffix_str)
@@ -405,11 +412,19 @@ def archive_to_csv(network):
     csv_archive_path, _ = output_path(network, "_", "_", "_",
                             errors="ignore",
                             extra_archive=archive_suffix_str)
-    
+
     # Get the file list for the nc archive
     _, nc_sub_path, files = data_file_list(network,
                                         paths.output_path,
                                         errors="ignore_inputs")
+
+    # A zip-based .nc archive nests its members under a top-level version folder;
+    # strip that prefix so the csv paths mirror it rather than double-nesting.
+    nc_archive_path = data_file_path("", network, sub_path=paths.output_path,
+                                     errors="ignore_inputs")
+    nc_root_prefix = ""
+    if nc_archive_path.suffix == ".zip":
+        nc_root_prefix = archive_zip_root(nc_archive_path, version) + "/"
 
     logger.info(f"Converting {len(files)} files to CSV format...")
 
@@ -418,13 +433,18 @@ def archive_to_csv(network):
         # directory-based archive; there is nothing to convert or copy for those.
         if f.endswith("/"):
             continue
-        if not f.endswith(".nc"):
+
+        # Relative path within the archive (prefix present only for zip archives)
+        rel = f[len(nc_root_prefix):] if nc_root_prefix and f.startswith(nc_root_prefix) else f
+
+        if not rel.endswith(".nc"):
             # Copy the file as is
-            archive_write_csv(csv_archive_path, f,
-                            data_file_path(f, network).read_text(encoding='utf-8'))
+            archive_write_csv(csv_archive_path, rel,
+                            data_file_path(rel, network).read_text(encoding='utf-8'),
+                            version=version)
 
         else:
-            filename_csv = f"{f.split('.nc')[0]}.csv"
+            filename_csv = f"{rel.split('.nc')[0]}.csv"
 
             with open_data_file(f, network, sub_path = nc_sub_path) as ncf:
                 with xr.open_dataset(ncf) as nc_ds:
@@ -434,7 +454,8 @@ def archive_to_csv(network):
             header, df = nc_to_csv(ds)
             output_data = "\n".join(header) + "\n" + df.to_csv(index=False)
 
-            archive_write_csv(csv_archive_path, filename_csv, output_data)
+            archive_write_csv(csv_archive_path, filename_csv, output_data,
+                            version=version)
 
 
 def compare_archive_versions(version_1, version_2):

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -152,9 +152,10 @@ def archive(request):
     (data_file_path, output_write, create_empty_archive, delete_archive); only the
     directory path was covered before. Running the same golden manifest against zip output
     pins the zip write path end to end — the path used by the downstream dvc-tracked
-    release repositories. Zip members are stored under their archive path with no stem
-    prefix, so extracting the archive reproduces the exact directory tree and the existing
-    reader compares against the same reference manifest.
+    release repositories. Zip members nest under a single top-level folder (named after the
+    archive and version) so the archive extracts into one self-named directory; descending
+    into that folder reproduces the exact directory tree, which is compared against the same
+    reference manifest.
 
     Returns:
         tuple[dict, list[str]]: Manifest, and the contents of any error log written.
@@ -184,7 +185,12 @@ def archive(request):
             with tempfile.TemporaryDirectory() as extract_dir:
                 with ZipFile(zip_path, "r") as archive_zip:
                     archive_zip.extractall(extract_dir)
-                manifest = archive_manifest(extract_dir)
+                # The archive must extract into a single self-named top-level folder;
+                # descend into it so the manifest mirrors the directory backend.
+                roots = [p for p in Path(extract_dir).iterdir() if not p.name.startswith(".")]
+                assert len(roots) == 1 and roots[0].is_dir(), \
+                    f"expected a single top-level folder in the zip, found {[p.name for p in roots]}"
+                manifest = archive_manifest(roots[0])
         else:
             manifest = archive_manifest(out_dir)
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -101,6 +101,46 @@ def test_nc_to_csv():
     assert df["second"].tolist() == [0, 0, 0, 0, 0], "Second column does not have the expected data."
 
 
+def test_nest_archive_zip(monkeypatch):
+    """nest_archive_zip repackages a flat zip under one top-level folder, idempotently.
+
+    Uses the agage_test network with its output redirected to a zip, then writes members
+    at archive-relative paths (as the processing pipeline does) before nesting.
+    """
+
+    from tests.test_archive import _patch_config_output, NETWORK
+    from agage_archive.config import nest_archive_zip, output_path, archive_zip_root, load_json
+
+    _patch_config_output(monkeypatch, "output.zip")
+
+    archive, _ = output_path(NETWORK, "_", "_", "_", errors="ignore")
+    if archive.exists():
+        archive.unlink()
+
+    # Write members at archive-relative paths, mimicking the finished pipeline output
+    with ZipFile(archive, "w") as z:
+        z.writestr("README.md", "readme")
+        z.writestr("ch4/agage_test_mhd_ch4_testv1.nc", "data")
+
+    version = load_json("attributes.json", network=NETWORK).get("version", "")
+    root = archive_zip_root(archive, version)
+
+    try:
+        nest_archive_zip(NETWORK)
+        with ZipFile(archive) as z:
+            names = sorted(z.namelist())
+        assert names == [f"{root}/README.md", f"{root}/ch4/agage_test_mhd_ch4_testv1.nc"]
+        assert {n.split("/", 1)[0] for n in names} == {root}, "must extract into one folder"
+
+        # Idempotent: a second call must not double-nest
+        nest_archive_zip(NETWORK)
+        with ZipFile(archive) as z:
+            assert sorted(z.namelist()) == names
+    finally:
+        if archive.exists():
+            archive.unlink()
+
+
 def test_archive_write_csv():
     """Test the archive_write_csv function."""
 
@@ -114,17 +154,19 @@ def test_archive_write_csv():
         filename_with_subpath = "subfolder/test_output.csv"
         
         data = "col1,col2\n1,2\n3,4"
+        version = "testv1"
 
-        archive_write_csv(zip_path, filename, data)
-        archive_write_csv(zip_path, filename_with_subpath, data)
+        archive_write_csv(zip_path, filename, data, version=version)
+        archive_write_csv(zip_path, filename_with_subpath, data, version=version)
 
         # Check if the file was created
         with ZipFile(zip_path, mode="r") as zip:
 
-            # output_write_csv prepends the archive name to the output filename
-            zip_stem = zip_path.stem
-            filename_in_zip = f"{zip_stem}/{filename}"
-            filename_with_subpath_in_zip = f"{zip_stem}/{filename_with_subpath}"
+            # Members nest under a single "<archive stem>-<version>" folder so the
+            # zip extracts into one self-named directory, matching the .nc archive.
+            root = f"{zip_path.stem}-{version}"
+            filename_in_zip = f"{root}/{filename}"
+            filename_with_subpath_in_zip = f"{root}/{filename_with_subpath}"
 
             # Check if the file exists in the zip
             assert filename_in_zip in zip.namelist(), f"{filename_in_zip} not found in zip"


### PR DESCRIPTION
## Summary

Both the `.nc` and CSV zip archives now extract into **one self-named top-level directory** rather than scattering their contents into the extraction directory:

- `.nc` archive → `agage-public-archive-<version>/`
- CSV archive → `agage-public-archive-csv-<version>/`

The version comes from the network's `attributes.json` (e.g. `testv1`). Directory-based outputs are unchanged — a directory is already a named container.

### Why

The CSV archive already nested under its archive name, but the `.nc` archive extracted at the root level, so the two were inconsistent. Nesting under a single top-level folder is the standard convention (GitHub tarballs, dataset archives, most software distributions) — it avoids the "unzip dumps loose files everywhere" surprise, which has no easy undo. This brings **both** archives into line with that convention.

## Approach

The naive fix — prefixing every zip member as it is written — **corrupts the archive**. The processing pipeline reads its own output back mid-run (e.g. the recommended-file pattern match in `run_all`, run.py:197, uses `fnmatch` on archive-relative paths). A prefixed member name breaks that match, so the guard misfires and the combined baseline is written twice, losing its time encoding via the zip replace-branch. The golden manifest test catches this.

Instead, the whole pipeline keeps writing **archive-relative member paths** exactly as before, and the zip is repackaged under the top-level folder as a **final step**:

- **`config.py`**: `archive_zip_root()` computes `<stem>-<version>`; `nest_archive_zip()` streams the finished zip into a single top-level folder (member-by-member, tmp file + atomic replace, idempotent on re-runs).
- **`run.py`**: `run_all` calls `nest_archive_zip` last, after all combine read-backs are done.
- **`util.py`**: `archive_write_csv`/`archive_to_csv` nest the CSV archive and strip the `.nc` archive's version-folder prefix when reading it back, so CSV paths mirror the `.nc` paths rather than double-nesting.

## Testing

- Full suite: **123 passed**.
- Golden manifest (`test_archive.py`) zip fixture descends into the single top-level folder and asserts exactly one root — confirms `.nc` content is byte-identical to before, only the physical layout changed.
- New `test_nest_archive_zip` unit test covers nesting and idempotency (no `run_all` needed).
- Manually verified the production zip→zip path end-to-end: single root per archive, `.nc`↔CSV paths mirrored, no double-nesting.

## Caveat

`run_all(delete=False)` over an *already-nested* archive would make the pipeline read nested names and hit the original pattern-match problem. The normal flow is `delete=True` (the default), which rebuilds from scratch, so this only affects deliberately appending to a finished, nested archive. Can add a flatten-on-entry guard if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)